### PR TITLE
시큐리티 필터 오류 해결 #10

### DIFF
--- a/src/main/java/com/sendback/global/config/auth/SecurityConfig.java
+++ b/src/main/java/com/sendback/global/config/auth/SecurityConfig.java
@@ -1,15 +1,11 @@
 package com.sendback.global.config.auth;
 
-import com.sendback.global.config.auth.ExceptionHandlerFilter;
-import com.sendback.global.config.auth.JwtAuthenticationFilter;
-import com.sendback.global.config.auth.JwtAuthenticationEntryPoint;
 import com.sendback.global.config.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
@@ -17,7 +13,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
 import java.util.Collections;
 
 @Configuration
@@ -27,10 +22,10 @@ public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-    private static final String[] PUBLIC_URLS = {
-            "api/auth/kakao/callback",
-            "api/auth/google/callback",
-            "api/auth/reissue"
+    protected static final String[] PERMITTED_URLS = {
+            "/api/auth/kakao/callback",
+            "/api/auth/google/callback",
+            "/api/auth/reissue",
     };
 
     @Bean
@@ -45,14 +40,16 @@ public class SecurityConfig {
 
                 .exceptionHandling(exceptionHandlingConfigurer ->
                         exceptionHandlingConfigurer.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new ExceptionHandlerFilter(), JwtAuthenticationFilter.class)
 
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(PUBLIC_URLS).permitAll()
+                        .requestMatchers(PERMITTED_URLS).permitAll()
                         .anyRequest().authenticated()
                 )
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+
                 .build();
     }
 

--- a/src/main/java/com/sendback/global/config/auth/SecurityConfig.java
+++ b/src/main/java/com/sendback/global/config/auth/SecurityConfig.java
@@ -26,6 +26,7 @@ public class SecurityConfig {
             "/api/auth/kakao/callback",
             "/api/auth/google/callback",
             "/api/auth/reissue",
+            "/"
     };
 
     @Bean


### PR DESCRIPTION
## 📕 연관 이슈 번호
https://github.com/dnd-side-project/dnd-10th-7-backend/issues/10

## 📙 작업 내용

> 구현 내용 및 작업 했던 내역

permitted_url에 들어있는 api는 요청시 인증/인가 필터 건너띄고 나머지는 인증/인가 필터를 타도록 구현했습니다.
```java
private static final String[] PERMITTED_URLS = {
            "api/auth/kakao/callback",
            "api/auth/google/callback",
            "api/auth/reissue"
    };
```
그런데 확인해보니까 모든 api 요청마다 아래 예외 메시지가 떴습니다. 따라서 Jwt 인증 필터에 isPermittedUrl 메서드를 구현해서 분기처리 했습니다. 
```java
{
    "code": 1030,
    "message": "유효하지 않은 access token 입니다."
}
```
## 📗 논의 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이사항1
- 특이사항2

## 📘 체크리스트
- [ o]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [ o]  라벨 체크해주세요.
- [ o]  .yml 파일 수정 내용이 있다면 공유해주세요.