### PR TITLE
피드백 등록, 상세 조회, 제출 API #21

### DIFF
--- a/src/docs/asciidoc/api/feedback.adoc
+++ b/src/docs/asciidoc/api/feedback.adoc
@@ -1,0 +1,46 @@
+[[Feedback-API]]
+= Feedback API
+
+[[feedback-detail]]
+== 피드백 상세 조회
+
+=== 성공
+
+==== HTTP Requests
+include::{snippets}/feedback/detail/http-request.adoc[]
+include::{snippets}/feedback/detail/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/feedback/detail/http-response.adoc[]
+include::{snippets}/feedback/detail/response-fields.adoc[]
+
+'''
+
+[[feedback-save]]
+== 피드백 등록
+
+=== 성공
+
+==== HTTP Requests
+include::{snippets}/feedback/save/http-request.adoc[]
+include::{snippets}/feedback/save/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/feedback/save/http-response.adoc[]
+include::{snippets}/feedback/save/response-fields.adoc[]
+
+'''
+
+[[feedback-submit]]
+== 피드백 제출
+
+=== 성공
+
+==== HTTP Requests
+include::{snippets}/feedback/submit/http-request.adoc[]
+include::{snippets}/feedback/submit/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/feedback/submit/http-response.adoc[]
+include::{snippets}/feedback/submit/response-fields.adoc[]
+

--- a/src/docs/asciidoc/api/like.adoc
+++ b/src/docs/asciidoc/api/like.adoc
@@ -1,17 +1,11 @@
 [[Like-API]]
 = Like API
 
-[[like]]
-== 좋아요
-
-[[react]]
-=== 반응
-
+[[like-react]]
+== 좋아요 반응
+=== 성공
 ==== HTTP Requests
 include::{snippets}/like/react/http-request.adoc[]
-
-- *header*
-include::{snippets}/like/react/request-headers.adoc[]
 
 ==== HTTP Response
 include::{snippets}/like/react/http-response.adoc[]

--- a/src/docs/asciidoc/api/project.adoc
+++ b/src/docs/asciidoc/api/project.adoc
@@ -2,18 +2,14 @@
 [[Project-API]]
 = Project API
 
-[[project]]
-== 프로젝트
+[[project-save]]
+== 프로젝트 등록
 
-[[save]]
-=== 등록
+=== 성공
 
 ==== HTTP Requests
 include::{snippets}/project/save/http-request.adoc[]
 
-- *header*
-include::{snippets}/project/save/request-headers.adoc[]
----
 - *body*
 include::{snippets}/project/save/request-parts.adoc[]
 data
@@ -23,14 +19,14 @@ include::{snippets}/project/save/request-part-data-fields.adoc[]
 include::{snippets}/project/save/http-response.adoc[]
 include::{snippets}/project/save/response-fields.adoc[]
 
-[[update]]
-=== 수정
+[[project-update]]
+== 프로젝트 수정
+
+=== 성공
 
 ==== HTTP Requests
 include::{snippets}/project/update/http-request.adoc[]
 
-- *header*
-include::{snippets}/project/update/request-headers.adoc[]
 - *body*
 include::{snippets}/project/update/request-parts.adoc[]
 data
@@ -40,13 +36,13 @@ include::{snippets}/project/update/request-part-data-fields.adoc[]
 include::{snippets}/project/update/http-response.adoc[]
 include::{snippets}/project/update/response-fields.adoc[]
 
-[[delete]]
-=== 삭제
+[[project-delete]]
+== 프로젝트 삭제
+
+=== 성공
 
 ==== HTTP Requests
 include::{snippets}/project/delete/http-request.adoc[]
-- *header*
-include::{snippets}/project/delete/request-headers.adoc[]
 
 
 ==== HTTP Response

--- a/src/docs/asciidoc/api/scrap.adoc
+++ b/src/docs/asciidoc/api/scrap.adoc
@@ -1,17 +1,13 @@
 [[Scrap-API]]
 = Scrap API
 
-[[scrap]]
-== 스크랩
+[[scrap-click]]
+== 스크랩 클릭
 
-[[click]]
-=== 클릭
+=== 성공
 
 ==== HTTP Requests
 include::{snippets}/scrap/click/http-request.adoc[]
-
-- *header*
-include::{snippets}/scrap/click/request-headers.adoc[]
 
 ==== HTTP Response
 include::{snippets}/scrap/click/http-response.adoc[]

--- a/src/main/java/com/sendback/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/sendback/domain/feedback/controller/FeedbackController.java
@@ -1,9 +1,9 @@
 package com.sendback.domain.feedback.controller;
 
-import com.sendback.domain.feedback.dto.request.SaveFeedbackRequest;
-import com.sendback.domain.feedback.dto.response.FeedbackDetailResponse;
-import com.sendback.domain.feedback.dto.response.FeedbackIdResponse;
-import com.sendback.domain.feedback.dto.response.SubmitFeedbackResponse;
+import com.sendback.domain.feedback.dto.request.SaveFeedbackRequestDto;
+import com.sendback.domain.feedback.dto.response.FeedbackDetailResponseDto;
+import com.sendback.domain.feedback.dto.response.FeedbackIdResponseDto;
+import com.sendback.domain.feedback.dto.response.SubmitFeedbackResponseDto;
 import com.sendback.domain.feedback.service.FeedbackService;
 import com.sendback.global.common.ApiResponse;
 import com.sendback.global.common.UserId;
@@ -23,22 +23,22 @@ public class FeedbackController {
     private final FeedbackService feedbackService;
 
     @PostMapping("/{projectId}/feedback")
-    public ApiResponse<FeedbackIdResponse> save(
+    public ApiResponse<FeedbackIdResponseDto> saveFeedback(
             @UserId Long userId,
             @PathVariable Long projectId,
-            @RequestBody @Valid SaveFeedbackRequest saveFeedbackRequest) {
-        return success(feedbackService.saveFeedback(userId, projectId, saveFeedbackRequest));
+            @RequestBody @Valid SaveFeedbackRequestDto saveFeedbackRequestDto) {
+        return success(feedbackService.saveFeedback(userId, projectId, saveFeedbackRequestDto));
     }
 
     @GetMapping("/{projectId}/feedbacks/{feedbackId}")
-    public ApiResponse<FeedbackDetailResponse> getDetail(
+    public ApiResponse<FeedbackDetailResponseDto> getFeedbackDetail(
             @PathVariable Long projectId,
             @PathVariable Long feedbackId) {
         return success(feedbackService.getFeedbackDetail(projectId, feedbackId));
     }
 
     @PostMapping(value = "/{projectId}/feedbacks/{feedbackId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<SubmitFeedbackResponse> submit(
+    public ApiResponse<SubmitFeedbackResponseDto> submitFeedback(
             @UserId Long userId,
             @PathVariable Long projectId,
             @PathVariable Long feedbackId,

--- a/src/main/java/com/sendback/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/sendback/domain/feedback/controller/FeedbackController.java
@@ -7,6 +7,7 @@ import com.sendback.domain.feedback.dto.response.SubmitFeedbackResponse;
 import com.sendback.domain.feedback.service.FeedbackService;
 import com.sendback.global.common.ApiResponse;
 import com.sendback.global.common.UserId;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -25,7 +26,7 @@ public class FeedbackController {
     public ApiResponse<FeedbackIdResponse> save(
             @UserId Long userId,
             @PathVariable Long projectId,
-            @RequestBody SaveFeedbackRequest saveFeedbackRequest) {
+            @RequestBody @Valid SaveFeedbackRequest saveFeedbackRequest) {
         return success(feedbackService.saveFeedback(userId, projectId, saveFeedbackRequest));
     }
 

--- a/src/main/java/com/sendback/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/sendback/domain/feedback/controller/FeedbackController.java
@@ -1,0 +1,47 @@
+package com.sendback.domain.feedback.controller;
+
+import com.sendback.domain.feedback.dto.request.SaveFeedbackRequest;
+import com.sendback.domain.feedback.dto.response.FeedbackDetailResponse;
+import com.sendback.domain.feedback.dto.response.FeedbackIdResponse;
+import com.sendback.domain.feedback.dto.response.SubmitFeedbackResponse;
+import com.sendback.domain.feedback.service.FeedbackService;
+import com.sendback.global.common.ApiResponse;
+import com.sendback.global.common.UserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import static com.sendback.global.common.ApiResponse.success;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/api/projects")
+public class FeedbackController {
+
+    private final FeedbackService feedbackService;
+
+    @PostMapping("/{projectId}/feedback")
+    public ApiResponse<FeedbackIdResponse> save(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @RequestBody SaveFeedbackRequest saveFeedbackRequest) {
+        return success(feedbackService.saveFeedback(userId, projectId, saveFeedbackRequest));
+    }
+
+    @GetMapping("/{projectId}/feedbacks/{feedbackId}")
+    public ApiResponse<FeedbackDetailResponse> getDetail(
+            @PathVariable Long projectId,
+            @PathVariable Long feedbackId) {
+        return success(feedbackService.getFeedbackDetail(projectId, feedbackId));
+    }
+
+    @PostMapping(value = "/{projectId}/feedbacks/{feedbackId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<SubmitFeedbackResponse> submit(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long feedbackId,
+            @ModelAttribute MultipartFile file) {
+        return success(feedbackService.submitFeedback(userId, feedbackId, file));
+    }
+}

--- a/src/main/java/com/sendback/domain/feedback/dto/request/SaveFeedbackRequest.java
+++ b/src/main/java/com/sendback/domain/feedback/dto/request/SaveFeedbackRequest.java
@@ -1,12 +1,24 @@
 package com.sendback.domain.feedback.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 import java.time.LocalDate;
 
 public record SaveFeedbackRequest(
+        @Size(max = 30, message = "제목은 글자 수가 최대 30글자 입니다.")
+        @NotBlank(message = "제목은 비워둘 수 없습니다.")
         String title,
+        @NotBlank
         String linkUrl,
+        @Size(max = 500, message = "설명은 글자 수가 최대 500자 입니다.")
+        @NotBlank(message = "설명은 비워둘 수 없습니다.")
         String content,
+        @Size(max = 100, message = "추가 리워드는 글자 수가 최대 100자 입니다.")
         String rewardMessage,
+        @NotNull(message = "시작 날짜는 비워둘 수 없습니다.")
         LocalDate startedAt,
+        @NotNull(message = "끝나는 날짜는 비워둘 수 없습니다.")
         LocalDate endedAt
 ) {}

--- a/src/main/java/com/sendback/domain/feedback/dto/request/SaveFeedbackRequest.java
+++ b/src/main/java/com/sendback/domain/feedback/dto/request/SaveFeedbackRequest.java
@@ -1,0 +1,12 @@
+package com.sendback.domain.feedback.dto.request;
+
+import java.time.LocalDate;
+
+public record SaveFeedbackRequest(
+        String title,
+        String linkUrl,
+        String content,
+        String rewardMessage,
+        LocalDate startedAt,
+        LocalDate endedAt
+) {}

--- a/src/main/java/com/sendback/domain/feedback/dto/request/SaveFeedbackRequestDto.java
+++ b/src/main/java/com/sendback/domain/feedback/dto/request/SaveFeedbackRequestDto.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 
-public record SaveFeedbackRequest(
+public record SaveFeedbackRequestDto(
         @Size(max = 30, message = "제목은 글자 수가 최대 30글자 입니다.")
         @NotBlank(message = "제목은 비워둘 수 없습니다.")
         String title,

--- a/src/main/java/com/sendback/domain/feedback/dto/response/FeedbackDetailResponse.java
+++ b/src/main/java/com/sendback/domain/feedback/dto/response/FeedbackDetailResponse.java
@@ -1,0 +1,50 @@
+package com.sendback.domain.feedback.dto.response;
+
+import com.sendback.domain.feedback.entity.Feedback;
+import com.sendback.domain.project.entity.Project;
+import com.sendback.domain.user.entity.User;
+
+import static com.sendback.global.util.CustomDateUtil.customDateFormat;
+
+public record FeedbackDetailResponse(
+
+        Long userId,
+        String username,
+        String userLevel,
+        String profileImageUrl,
+        Long feedbackId,
+        String feedbackTitle,
+        String linkUrl,
+        String content,
+        String rewardMessage,
+        String createdAt,
+        String startedAt,
+        String endedAt,
+        Long projectId,
+        String projectTitle,
+        String field,
+        String progress
+) {
+    public static FeedbackDetailResponse of(Feedback feedback) {
+        Project project = feedback.getProject();
+        User user = project.getUser();
+        return new FeedbackDetailResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getLevel().getName(),
+                user.getProfileImageUrl(),
+                feedback.getId(),
+                feedback.getTitle(),
+                feedback.getLinkUrl(),
+                feedback.getContent(),
+                feedback.getRewardMessage(),
+                customDateFormat(feedback.getCreatedAt()),
+                feedback.getStartedAt().toString(),
+                feedback.getEndedAt().toString(),
+                project.getId(),
+                project.getTitle(),
+                project.getField().getName(),
+                project.getProgress().toString()
+        );
+    }
+}

--- a/src/main/java/com/sendback/domain/feedback/dto/response/FeedbackDetailResponseDto.java
+++ b/src/main/java/com/sendback/domain/feedback/dto/response/FeedbackDetailResponseDto.java
@@ -6,7 +6,7 @@ import com.sendback.domain.user.entity.User;
 
 import static com.sendback.global.util.CustomDateUtil.customDateFormat;
 
-public record FeedbackDetailResponse(
+public record FeedbackDetailResponseDto(
 
         Long userId,
         String username,
@@ -25,10 +25,10 @@ public record FeedbackDetailResponse(
         String field,
         String progress
 ) {
-    public static FeedbackDetailResponse of(Feedback feedback) {
+    public static FeedbackDetailResponseDto of(Feedback feedback) {
         Project project = feedback.getProject();
         User user = project.getUser();
-        return new FeedbackDetailResponse(
+        return new FeedbackDetailResponseDto(
                 user.getId(),
                 user.getNickname(),
                 user.getLevel().getName(),

--- a/src/main/java/com/sendback/domain/feedback/dto/response/FeedbackIdResponse.java
+++ b/src/main/java/com/sendback/domain/feedback/dto/response/FeedbackIdResponse.java
@@ -1,3 +1,0 @@
-package com.sendback.domain.feedback.dto.response;
-
-public record FeedbackIdResponse(Long feedbackId) {}

--- a/src/main/java/com/sendback/domain/feedback/dto/response/FeedbackIdResponse.java
+++ b/src/main/java/com/sendback/domain/feedback/dto/response/FeedbackIdResponse.java
@@ -1,0 +1,3 @@
+package com.sendback.domain.feedback.dto.response;
+
+public record FeedbackIdResponse(Long feedbackId) {}

--- a/src/main/java/com/sendback/domain/feedback/dto/response/FeedbackIdResponseDto.java
+++ b/src/main/java/com/sendback/domain/feedback/dto/response/FeedbackIdResponseDto.java
@@ -1,0 +1,3 @@
+package com.sendback.domain.feedback.dto.response;
+
+public record FeedbackIdResponseDto(Long feedbackId) {}

--- a/src/main/java/com/sendback/domain/feedback/dto/response/SubmitFeedbackResponse.java
+++ b/src/main/java/com/sendback/domain/feedback/dto/response/SubmitFeedbackResponse.java
@@ -1,0 +1,7 @@
+package com.sendback.domain.feedback.dto.response;
+
+public record SubmitFeedbackResponse(
+        String level,
+        boolean isLevelUp,
+        Long remainFeedbackCount
+) {}

--- a/src/main/java/com/sendback/domain/feedback/dto/response/SubmitFeedbackResponseDto.java
+++ b/src/main/java/com/sendback/domain/feedback/dto/response/SubmitFeedbackResponseDto.java
@@ -1,6 +1,6 @@
 package com.sendback.domain.feedback.dto.response;
 
-public record SubmitFeedbackResponse(
+public record SubmitFeedbackResponseDto(
         String level,
         boolean isLevelUp,
         Long remainFeedbackCount

--- a/src/main/java/com/sendback/domain/feedback/entity/Feedback.java
+++ b/src/main/java/com/sendback/domain/feedback/entity/Feedback.java
@@ -1,7 +1,7 @@
 package com.sendback.domain.feedback.entity;
 
 
-import com.sendback.domain.feedback.dto.request.SaveFeedbackRequest;
+import com.sendback.domain.feedback.dto.request.SaveFeedbackRequestDto;
 import com.sendback.domain.project.entity.Project;
 import com.sendback.domain.user.entity.User;
 import com.sendback.global.common.BaseEntity;
@@ -61,16 +61,16 @@ public class Feedback extends BaseEntity {
         this.endedAt = endedAt;
     }
 
-    public static Feedback of(User user, Project project, SaveFeedbackRequest saveFeedbackRequest) {
+    public static Feedback of(User user, Project project, SaveFeedbackRequestDto saveFeedbackRequestDto) {
         return Feedback.builder()
                 .user(user)
                 .project(project)
-                .title(saveFeedbackRequest.title())
-                .linkUrl(saveFeedbackRequest.linkUrl())
-                .content(saveFeedbackRequest.content())
-                .rewardMessage(saveFeedbackRequest.rewardMessage())
-                .startedAt(saveFeedbackRequest.startedAt())
-                .endedAt(saveFeedbackRequest.endedAt())
+                .title(saveFeedbackRequestDto.title())
+                .linkUrl(saveFeedbackRequestDto.linkUrl())
+                .content(saveFeedbackRequestDto.content())
+                .rewardMessage(saveFeedbackRequestDto.rewardMessage())
+                .startedAt(saveFeedbackRequestDto.startedAt())
+                .endedAt(saveFeedbackRequestDto.endedAt())
                 .build();
     }
 

--- a/src/main/java/com/sendback/domain/feedback/entity/Feedback.java
+++ b/src/main/java/com/sendback/domain/feedback/entity/Feedback.java
@@ -1,0 +1,77 @@
+package com.sendback.domain.feedback.entity;
+
+
+import com.sendback.domain.feedback.dto.request.SaveFeedbackRequest;
+import com.sendback.domain.project.entity.Project;
+import com.sendback.domain.user.entity.User;
+import com.sendback.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE feedback SET is_deleted = true WHERE id = ?")
+public class Feedback extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+    private String title;
+    private String linkUrl;
+    private String content;
+    private String rewardMessage;
+    private LocalDate startedAt;
+    private LocalDate endedAt;
+    private boolean isFinished = false;
+    private boolean isDeleted = false;
+
+    @Builder
+    private Feedback(
+            final User user,
+            final Project project,
+            final String title,
+            final String linkUrl,
+            final String content,
+            final String rewardMessage,
+            final LocalDate startedAt,
+            final LocalDate endedAt
+    ) {
+        this.user = user;
+        this.project = project;
+        this.title = title;
+        this.linkUrl = linkUrl;
+        this.content = content;
+        this.rewardMessage = rewardMessage;
+        this.startedAt = startedAt;
+        this.endedAt = endedAt;
+    }
+
+    public static Feedback of(User user, Project project, SaveFeedbackRequest saveFeedbackRequest) {
+        return Feedback.builder()
+                .user(user)
+                .project(project)
+                .title(saveFeedbackRequest.title())
+                .linkUrl(saveFeedbackRequest.linkUrl())
+                .content(saveFeedbackRequest.content())
+                .rewardMessage(saveFeedbackRequest.rewardMessage())
+                .startedAt(saveFeedbackRequest.startedAt())
+                .endedAt(saveFeedbackRequest.endedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/sendback/domain/feedback/entity/FeedbackSubmit.java
+++ b/src/main/java/com/sendback/domain/feedback/entity/FeedbackSubmit.java
@@ -1,0 +1,52 @@
+package com.sendback.domain.feedback.entity;
+
+import com.sendback.domain.user.entity.User;
+import com.sendback.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE feedback_submit SET is_deleted = true WHERE id = ?")
+public class FeedbackSubmit extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feedback_id")
+    private Feedback feedback;
+
+    private String screenShotUrl;
+    private boolean isDeleted = false;
+
+    @Builder
+    private FeedbackSubmit(
+            final User user,
+            final Feedback feedback,
+            final String screenShotUrl
+    ) {
+        this.user = user;
+        this.feedback = feedback;
+        this.screenShotUrl = screenShotUrl;
+    }
+
+    public static FeedbackSubmit of(User user, Feedback feedback, String screenShotUrl) {
+        return FeedbackSubmit.builder()
+                .user(user)
+                .feedback(feedback)
+                .screenShotUrl(screenShotUrl)
+                .build();
+    }
+
+}

--- a/src/main/java/com/sendback/domain/feedback/exception/FeedbackExceptionType.java
+++ b/src/main/java/com/sendback/domain/feedback/exception/FeedbackExceptionType.java
@@ -1,0 +1,15 @@
+package com.sendback.domain.feedback.exception;
+
+import com.sendback.global.exception.ExceptionType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum FeedbackExceptionType implements ExceptionType {
+
+    NOT_FOUND_FEEDBACK(3000, "요청한 피드백을 찾을 수 없습니다."),
+    DUPLICATE_FEEDBACK_SUBMIT(3010, "중복된 유저가 피드백을 제출했습니다.");
+    private final int statusCode;
+    private final String message;
+}

--- a/src/main/java/com/sendback/domain/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/com/sendback/domain/feedback/repository/FeedbackRepository.java
@@ -1,0 +1,7 @@
+package com.sendback.domain.feedback.repository;
+
+import com.sendback.domain.feedback.entity.Feedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+}

--- a/src/main/java/com/sendback/domain/feedback/repository/FeedbackSubmitRepository.java
+++ b/src/main/java/com/sendback/domain/feedback/repository/FeedbackSubmitRepository.java
@@ -1,0 +1,13 @@
+package com.sendback.domain.feedback.repository;
+
+import com.sendback.domain.feedback.entity.Feedback;
+import com.sendback.domain.feedback.entity.FeedbackSubmit;
+import com.sendback.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedbackSubmitRepository extends JpaRepository<FeedbackSubmit, Long> {
+
+    boolean existsByUserAndFeedbackAndIsDeletedIsFalse(User user, Feedback feedback);
+    Long countByUserAndIsDeletedIsFalse(User user);
+
+}

--- a/src/main/java/com/sendback/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/sendback/domain/feedback/service/FeedbackService.java
@@ -1,9 +1,9 @@
 package com.sendback.domain.feedback.service;
 
-import com.sendback.domain.feedback.dto.request.SaveFeedbackRequest;
-import com.sendback.domain.feedback.dto.response.FeedbackDetailResponse;
-import com.sendback.domain.feedback.dto.response.FeedbackIdResponse;
-import com.sendback.domain.feedback.dto.response.SubmitFeedbackResponse;
+import com.sendback.domain.feedback.dto.request.SaveFeedbackRequestDto;
+import com.sendback.domain.feedback.dto.response.FeedbackDetailResponseDto;
+import com.sendback.domain.feedback.dto.response.FeedbackIdResponseDto;
+import com.sendback.domain.feedback.dto.response.SubmitFeedbackResponseDto;
 import com.sendback.domain.feedback.entity.Feedback;
 import com.sendback.domain.feedback.entity.FeedbackSubmit;
 import com.sendback.domain.feedback.repository.FeedbackRepository;
@@ -36,23 +36,23 @@ public class FeedbackService {
     private final FeedbackSubmitRepository feedbackSubmitRepository;
 
     @Transactional
-    public FeedbackIdResponse saveFeedback(Long userId, Long projectId, SaveFeedbackRequest saveFeedbackRequest) {
+    public FeedbackIdResponseDto saveFeedback(Long userId, Long projectId, SaveFeedbackRequestDto saveFeedbackRequestDto) {
         User loginUser = userService.getUserById(userId);
         Project project = projectService.getProjectById(projectId);
 
         projectService.validateProjectAuthor(loginUser, project);
 
-        Feedback feedback = Feedback.of(loginUser, project, saveFeedbackRequest);
+        Feedback feedback = Feedback.of(loginUser, project, saveFeedbackRequestDto);
         Long responseId = feedbackRepository.save(feedback).getId();
 
-        return new FeedbackIdResponse(responseId);
+        return new FeedbackIdResponseDto(responseId);
     }
 
-    public FeedbackDetailResponse getFeedbackDetail(Long projectId, Long feedbackId) {
+    public FeedbackDetailResponseDto getFeedbackDetail(Long projectId, Long feedbackId) {
         projectService.getProjectById(projectId);
         Feedback feedback = getFeedback(feedbackId);
 
-        return FeedbackDetailResponse.of(feedback);
+        return FeedbackDetailResponseDto.of(feedback);
     }
 
     public Feedback getFeedback(Long feedbackId) {
@@ -61,7 +61,7 @@ public class FeedbackService {
     }
 
     @Transactional
-    public SubmitFeedbackResponse submitFeedback(Long userId, Long feedbackId, MultipartFile file) {
+    public SubmitFeedbackResponseDto submitFeedback(Long userId, Long feedbackId, MultipartFile file) {
         User loginUser = userService.getUserById(userId);
         Feedback feedback = getFeedback(feedbackId);
 
@@ -75,7 +75,7 @@ public class FeedbackService {
         boolean isLevelUp = isLevelUpUserLevelBySubmitting(loginUser, submitCount);
         Long remainCount = Level.getRemainCountUntilNextLevel(submitCount);
 
-        return new SubmitFeedbackResponse(loginUser.getLevel().getName(), isLevelUp, remainCount);
+        return new SubmitFeedbackResponseDto(loginUser.getLevel().getName(), isLevelUp, remainCount);
     }
 
     private boolean isLevelUpUserLevelBySubmitting(User user, Long submitCount) {

--- a/src/main/java/com/sendback/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/sendback/domain/feedback/service/FeedbackService.java
@@ -1,0 +1,96 @@
+package com.sendback.domain.feedback.service;
+
+import com.sendback.domain.feedback.dto.request.SaveFeedbackRequest;
+import com.sendback.domain.feedback.dto.response.FeedbackDetailResponse;
+import com.sendback.domain.feedback.dto.response.FeedbackIdResponse;
+import com.sendback.domain.feedback.dto.response.SubmitFeedbackResponse;
+import com.sendback.domain.feedback.entity.Feedback;
+import com.sendback.domain.feedback.entity.FeedbackSubmit;
+import com.sendback.domain.feedback.repository.FeedbackRepository;
+import com.sendback.domain.feedback.repository.FeedbackSubmitRepository;
+import com.sendback.domain.project.entity.Project;
+import com.sendback.domain.project.service.ProjectService;
+import com.sendback.domain.user.entity.User;
+import com.sendback.domain.user.service.UserService;
+import com.sendback.global.common.constants.Level;
+import com.sendback.global.config.image.service.ImageService;
+import com.sendback.global.exception.type.BadRequestException;
+import com.sendback.global.exception.type.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import static com.sendback.domain.feedback.exception.FeedbackExceptionType.DUPLICATE_FEEDBACK_SUBMIT;
+import static com.sendback.domain.feedback.exception.FeedbackExceptionType.NOT_FOUND_FEEDBACK;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FeedbackService {
+
+    private final UserService userService;
+    private final ProjectService projectService;
+    private final ImageService imageService;
+    private final FeedbackRepository feedbackRepository;
+    private final FeedbackSubmitRepository feedbackSubmitRepository;
+
+    @Transactional
+    public FeedbackIdResponse saveFeedback(Long userId, Long projectId, SaveFeedbackRequest saveFeedbackRequest) {
+        User loginUser = userService.getUserById(userId);
+        Project project = projectService.getProjectById(projectId);
+
+        projectService.validateProjectAuthor(loginUser, project);
+
+        Feedback feedback = Feedback.of(loginUser, project, saveFeedbackRequest);
+        Long responseId = feedbackRepository.save(feedback).getId();
+
+        return new FeedbackIdResponse(responseId);
+    }
+
+    public FeedbackDetailResponse getFeedbackDetail(Long projectId, Long feedbackId) {
+        projectService.getProjectById(projectId);
+        Feedback feedback = getFeedback(feedbackId);
+
+        return FeedbackDetailResponse.of(feedback);
+    }
+
+    public Feedback getFeedback(Long feedbackId) {
+        return feedbackRepository.findById(feedbackId)
+                .orElseThrow(() -> new NotFoundException(NOT_FOUND_FEEDBACK));
+    }
+
+    @Transactional
+    public SubmitFeedbackResponse submitFeedback(Long userId, Long feedbackId, MultipartFile file) {
+        User loginUser = userService.getUserById(userId);
+        Feedback feedback = getFeedback(feedbackId);
+
+        validateAlreadySubmit(loginUser, feedback);
+
+        String screenShotUrl = imageService.uploadImage(file, "feedback");
+        FeedbackSubmit feedbackSubmit = FeedbackSubmit.of(loginUser, feedback, screenShotUrl);
+        feedbackSubmitRepository.save(feedbackSubmit);
+
+        Long submitCount = feedbackSubmitRepository.countByUserAndIsDeletedIsFalse(loginUser);
+        boolean isLevelUp = isLevelUpUserLevelBySubmitting(loginUser, submitCount);
+        Long remainCount = Level.getRemainCountUntilNextLevel(submitCount);
+
+        return new SubmitFeedbackResponse(loginUser.getLevel().getName(), isLevelUp, remainCount);
+    }
+
+    private boolean isLevelUpUserLevelBySubmitting(User user, Long submitCount) {
+        Level level = Level.getLevelByFeedbackSubmitCount(submitCount);
+        if (user.getLevel().equals(level))
+            return false;
+
+        user.levelUp(level);
+        return true;
+    }
+
+    private void validateAlreadySubmit(User loginUser, Feedback feedback) {
+        boolean exists = feedbackSubmitRepository.existsByUserAndFeedbackAndIsDeletedIsFalse(loginUser, feedback);
+        if (exists)
+            throw new BadRequestException(DUPLICATE_FEEDBACK_SUBMIT);
+    }
+
+}

--- a/src/main/java/com/sendback/domain/like/controller/LikeController.java
+++ b/src/main/java/com/sendback/domain/like/controller/LikeController.java
@@ -1,6 +1,6 @@
 package com.sendback.domain.like.controller;
 
-import com.sendback.domain.like.dto.response.ReactLikeResponse;
+import com.sendback.domain.like.dto.response.ReactLikeResponseDto;
 import com.sendback.domain.like.service.LikeService;
 import com.sendback.global.common.ApiResponse;
 import com.sendback.global.common.UserId;
@@ -20,7 +20,7 @@ public class LikeController {
     private final LikeService likeService;
 
     @PutMapping("/{projectId}/like")
-    public ApiResponse<ReactLikeResponse> reactLike(
+    public ApiResponse<ReactLikeResponseDto> reactLike(
             @UserId Long userId,
             @PathVariable Long projectId) {
         return success(likeService.react(userId, projectId));

--- a/src/main/java/com/sendback/domain/like/dto/response/ReactLikeResponse.java
+++ b/src/main/java/com/sendback/domain/like/dto/response/ReactLikeResponse.java
@@ -1,3 +1,0 @@
-package com.sendback.domain.like.dto.response;
-
-public record ReactLikeResponse(boolean isReacted) {}

--- a/src/main/java/com/sendback/domain/like/dto/response/ReactLikeResponseDto.java
+++ b/src/main/java/com/sendback/domain/like/dto/response/ReactLikeResponseDto.java
@@ -1,0 +1,3 @@
+package com.sendback.domain.like.dto.response;
+
+public record ReactLikeResponseDto(boolean isReacted) {}

--- a/src/main/java/com/sendback/domain/like/service/LikeService.java
+++ b/src/main/java/com/sendback/domain/like/service/LikeService.java
@@ -23,16 +23,16 @@ public class LikeService {
     private final LikeRepository likeRepository;
 
     @Transactional
-    public ReactLikeResponseDto react(Long userId, Long projectId) {
+    public ReactLikeResponseDto reactLike(Long userId, Long projectId) {
         User loginUser = userService.getUserById(userId);
         Project project = projectService.getProjectById(projectId);
 
-        Like like = reactLike(loginUser, project);
+        Like like = react(loginUser, project);
 
         return new ReactLikeResponseDto(!like.isDeleted());
     }
 
-    private Like reactLike(User user, Project project) {
+    private Like react(User user, Project project) {
         Optional<Like> likeOptional = likeRepository.findByUserAndProject(user, project);
         if (likeOptional.isEmpty()) {
             Like like = Like.of(user, project);

--- a/src/main/java/com/sendback/domain/like/service/LikeService.java
+++ b/src/main/java/com/sendback/domain/like/service/LikeService.java
@@ -1,6 +1,6 @@
 package com.sendback.domain.like.service;
 
-import com.sendback.domain.like.dto.response.ReactLikeResponse;
+import com.sendback.domain.like.dto.response.ReactLikeResponseDto;
 import com.sendback.domain.like.entity.Like;
 import com.sendback.domain.like.repository.LikeRepository;
 import com.sendback.domain.project.entity.Project;
@@ -23,13 +23,13 @@ public class LikeService {
     private final LikeRepository likeRepository;
 
     @Transactional
-    public ReactLikeResponse react(Long userId, Long projectId) {
+    public ReactLikeResponseDto react(Long userId, Long projectId) {
         User loginUser = userService.getUserById(userId);
         Project project = projectService.getProjectById(projectId);
 
         Like like = reactLike(loginUser, project);
 
-        return new ReactLikeResponse(!like.isDeleted());
+        return new ReactLikeResponseDto(!like.isDeleted());
     }
 
     private Like reactLike(User user, Project project) {

--- a/src/main/java/com/sendback/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/sendback/domain/project/controller/ProjectController.java
@@ -1,8 +1,8 @@
 package com.sendback.domain.project.controller;
 
-import com.sendback.domain.project.dto.request.SaveProjectRequest;
-import com.sendback.domain.project.dto.request.UpdateProjectRequest;
-import com.sendback.domain.project.dto.response.ProjectIdResponse;
+import com.sendback.domain.project.dto.request.SaveProjectRequestDto;
+import com.sendback.domain.project.dto.request.UpdateProjectRequestDto;
+import com.sendback.domain.project.dto.response.ProjectIdResponseDto;
 import com.sendback.domain.project.service.ProjectService;
 import com.sendback.global.common.ApiResponse;
 import com.sendback.global.common.UserId;
@@ -24,20 +24,20 @@ public class ProjectController {
     private final ProjectService projectService;
 
     @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-    public ApiResponse<ProjectIdResponse> saveProject(
+    public ApiResponse<ProjectIdResponseDto> saveProject(
             @UserId Long userId,
-            @RequestPart(value = "data") @Valid SaveProjectRequest saveProjectRequest,
+            @RequestPart(value = "data") @Valid SaveProjectRequestDto saveProjectRequestDto,
             @RequestPart(value = "images", required = false) List<MultipartFile> images) {
-        return success(projectService.saveProject(userId, saveProjectRequest, images));
+        return success(projectService.saveProject(userId, saveProjectRequestDto, images));
     }
 
     @PutMapping(value = "/{projectId}", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-    public ApiResponse<ProjectIdResponse> updateProject(
+    public ApiResponse<ProjectIdResponseDto> updateProject(
             @UserId Long userId,
             @PathVariable Long projectId,
-            @RequestPart(value = "data") @Valid UpdateProjectRequest updateProjectRequest,
+            @RequestPart(value = "data") @Valid UpdateProjectRequestDto updateProjectRequestDto,
             @RequestPart(value = "images", required = false) List<MultipartFile> images) {
-        return success(projectService.updateProject(userId, projectId, updateProjectRequest, images));
+        return success(projectService.updateProject(userId, projectId, updateProjectRequestDto, images));
     }
 
     @DeleteMapping("/{projectId}")

--- a/src/main/java/com/sendback/domain/project/dto/request/SaveProjectRequestDto.java
+++ b/src/main/java/com/sendback/domain/project/dto/request/SaveProjectRequestDto.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 
-public record SaveProjectRequest(
+public record SaveProjectRequestDto(
         @Size(max = 30, message = "제목은 글자 수가 최대 30글자 입니다.")
         @NotBlank(message = "제목은 비워둘 수 없습니다.")
         String title,

--- a/src/main/java/com/sendback/domain/project/dto/request/UpdateProjectRequestDto.java
+++ b/src/main/java/com/sendback/domain/project/dto/request/UpdateProjectRequestDto.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.util.List;
 
-public record UpdateProjectRequest(
+public record UpdateProjectRequestDto(
 
         @Size(max = 30, message = "제목은 글자 수가 최대 30글자 입니다.")
         @NotBlank(message = "제목은 비워둘 수 없습니다.")

--- a/src/main/java/com/sendback/domain/project/dto/response/ProjectIdResponseDto.java
+++ b/src/main/java/com/sendback/domain/project/dto/response/ProjectIdResponseDto.java
@@ -1,4 +1,4 @@
 package com.sendback.domain.project.dto.response;
 
-public record ProjectIdResponse(Long projectId) {
+public record ProjectIdResponseDto(Long projectId) {
 }

--- a/src/main/java/com/sendback/domain/project/entity/Project.java
+++ b/src/main/java/com/sendback/domain/project/entity/Project.java
@@ -1,8 +1,8 @@
 package com.sendback.domain.project.entity;
 
 import com.sendback.domain.field.entity.Field;
-import com.sendback.domain.project.dto.request.SaveProjectRequest;
-import com.sendback.domain.project.dto.request.UpdateProjectRequest;
+import com.sendback.domain.project.dto.request.SaveProjectRequestDto;
+import com.sendback.domain.project.dto.request.UpdateProjectRequestDto;
 import com.sendback.domain.user.entity.User;
 import com.sendback.global.common.BaseEntity;
 import com.sendback.global.common.constants.Progress;
@@ -94,35 +94,35 @@ public class Project extends BaseEntity {
         this.isFinished = isFinished;
     }
 
-    public static Project of(User user, Field field, SaveProjectRequest saveProjectRequest) {
+    public static Project of(User user, Field field, SaveProjectRequestDto saveProjectRequestDto) {
         return Project.builder()
                 .user(user)
                 .field(field)
-                .title(saveProjectRequest.title())
-                .content(saveProjectRequest.content())
-                .summary(saveProjectRequest.summary())
-                .demoSiteUrl(saveProjectRequest.demoSiteUrl())
-                .startedAt(saveProjectRequest.startedAt())
-                .endedAt(saveProjectRequest.endedAt())
-                .progress(Progress.toEnum(saveProjectRequest.progress()))
-                .plannerCount(saveProjectRequest.plannerCount())
-                .frontendCount(saveProjectRequest.frontendCount())
-                .backendCount(saveProjectRequest.backendCount())
-                .designCount(saveProjectRequest.designCount())
+                .title(saveProjectRequestDto.title())
+                .content(saveProjectRequestDto.content())
+                .summary(saveProjectRequestDto.summary())
+                .demoSiteUrl(saveProjectRequestDto.demoSiteUrl())
+                .startedAt(saveProjectRequestDto.startedAt())
+                .endedAt(saveProjectRequestDto.endedAt())
+                .progress(Progress.toEnum(saveProjectRequestDto.progress()))
+                .plannerCount(saveProjectRequestDto.plannerCount())
+                .frontendCount(saveProjectRequestDto.frontendCount())
+                .backendCount(saveProjectRequestDto.backendCount())
+                .designCount(saveProjectRequestDto.designCount())
                 .isFinished(false)
                 .build();
     }
 
-    public void updateProject(Field field, UpdateProjectRequest updateProjectRequest) {
+    public void updateProject(Field field, UpdateProjectRequestDto updateProjectRequestDto) {
         this.field = field;
-        this.title = updateProjectRequest.title();
-        this.content = updateProjectRequest.content();
-        this.summary = updateProjectRequest.summary();
-        this.demoSiteUrl = updateProjectRequest.demoSiteUrl();
-        this.startedAt = updateProjectRequest.startedAt();
-        this.endedAt = updateProjectRequest.endedAt();
-        this.progress = Progress.toEnum(updateProjectRequest.progress());
-        this.projectParticipantCount = ProjectParticipantCount.of(updateProjectRequest);
+        this.title = updateProjectRequestDto.title();
+        this.content = updateProjectRequestDto.content();
+        this.summary = updateProjectRequestDto.summary();
+        this.demoSiteUrl = updateProjectRequestDto.demoSiteUrl();
+        this.startedAt = updateProjectRequestDto.startedAt();
+        this.endedAt = updateProjectRequestDto.endedAt();
+        this.progress = Progress.toEnum(updateProjectRequestDto.progress());
+        this.projectParticipantCount = ProjectParticipantCount.of(updateProjectRequestDto);
     }
 
     public boolean isAuthor(final User user) {

--- a/src/main/java/com/sendback/domain/project/entity/ProjectParticipantCount.java
+++ b/src/main/java/com/sendback/domain/project/entity/ProjectParticipantCount.java
@@ -1,6 +1,6 @@
 package com.sendback.domain.project.entity;
 
-import com.sendback.domain.project.dto.request.UpdateProjectRequest;
+import com.sendback.domain.project.dto.request.UpdateProjectRequestDto;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -18,8 +18,8 @@ public class ProjectParticipantCount {
     private long backendCount;
     private long designCount;
 
-    public static ProjectParticipantCount of(UpdateProjectRequest updateProjectRequest) {
-        return new ProjectParticipantCount(updateProjectRequest.plannerCount(), updateProjectRequest.frontendCount(),
-                updateProjectRequest.backendCount(), updateProjectRequest.designCount());
+    public static ProjectParticipantCount of(UpdateProjectRequestDto updateProjectRequestDto) {
+        return new ProjectParticipantCount(updateProjectRequestDto.plannerCount(), updateProjectRequestDto.frontendCount(),
+                updateProjectRequestDto.backendCount(), updateProjectRequestDto.designCount());
     }
 }

--- a/src/main/java/com/sendback/domain/project/service/ProjectService.java
+++ b/src/main/java/com/sendback/domain/project/service/ProjectService.java
@@ -112,7 +112,7 @@ public class ProjectService {
                 .orElseThrow(() -> new NotFoundException(NOT_FOUND_DELETE_IMAGE_URL));
     }
 
-    private void validateProjectAuthor(User user, Project project) {
+    public void validateProjectAuthor(User user, Project project) {
         if (!project.isAuthor(user))
             throw new BadRequestException(NOT_PROJECT_AUTHOR);
     }

--- a/src/main/java/com/sendback/domain/project/service/ProjectService.java
+++ b/src/main/java/com/sendback/domain/project/service/ProjectService.java
@@ -2,9 +2,9 @@ package com.sendback.domain.project.service;
 
 import com.sendback.domain.field.entity.Field;
 import com.sendback.domain.field.service.FieldService;
-import com.sendback.domain.project.dto.request.SaveProjectRequest;
-import com.sendback.domain.project.dto.request.UpdateProjectRequest;
-import com.sendback.domain.project.dto.response.ProjectIdResponse;
+import com.sendback.domain.project.dto.request.SaveProjectRequestDto;
+import com.sendback.domain.project.dto.request.UpdateProjectRequestDto;
+import com.sendback.domain.project.dto.response.ProjectIdResponseDto;
 import com.sendback.domain.project.entity.Project;
 import com.sendback.domain.project.entity.ProjectImage;
 import com.sendback.domain.project.repository.ProjectImageRepository;
@@ -35,15 +35,15 @@ public class ProjectService {
     private final ProjectImageRepository projectImageRepository;
 
     @Transactional
-    public ProjectIdResponse saveProject(Long userId, SaveProjectRequest saveProjectRequest, List<MultipartFile> images) {
+    public ProjectIdResponseDto saveProject(Long userId, SaveProjectRequestDto saveProjectRequestDto, List<MultipartFile> images) {
         User loginUser = userService.getUserById(userId);
 
-        Field field = fieldService.getFieldByName(saveProjectRequest.field());
-        Project project = Project.of(loginUser, field, saveProjectRequest);
+        Field field = fieldService.getFieldByName(saveProjectRequestDto.field());
+        Project project = Project.of(loginUser, field, saveProjectRequestDto);
 
         uploadProjectImage(project, images);
 
-        return new ProjectIdResponse(projectRepository.save(project).getId());
+        return new ProjectIdResponseDto(projectRepository.save(project).getId());
     }
 
     private void uploadProjectImage(Project project, List<MultipartFile> images) {
@@ -59,19 +59,19 @@ public class ProjectService {
     }
 
     @Transactional
-    public ProjectIdResponse updateProject(Long userId, Long projectId, UpdateProjectRequest updateProjectRequest, List<MultipartFile> images) {
+    public ProjectIdResponseDto updateProject(Long userId, Long projectId, UpdateProjectRequestDto updateProjectRequestDto, List<MultipartFile> images) {
         User loginUser = userService.getUserById(userId);
-        Field field = fieldService.getFieldByName(updateProjectRequest.field());
+        Field field = fieldService.getFieldByName(updateProjectRequestDto.field());
         Project project = getProjectById(projectId);
 
         validateProjectAuthor(loginUser, project);
-        validateProjectImageCount(project, images, updateProjectRequest.urlsToDelete());
+        validateProjectImageCount(project, images, updateProjectRequestDto.urlsToDelete());
 
-        deleteImageUrls(project, updateProjectRequest.urlsToDelete());
+        deleteImageUrls(project, updateProjectRequestDto.urlsToDelete());
         uploadProjectImage(project, images);
-        project.updateProject(field, updateProjectRequest);
+        project.updateProject(field, updateProjectRequestDto);
 
-        return new ProjectIdResponse(project.getId());
+        return new ProjectIdResponseDto(project.getId());
     }
 
     private void validateProjectImageCount(Project project, List<MultipartFile> images, List<String> urlsToDelete) {

--- a/src/main/java/com/sendback/domain/scrap/controller/ScrapController.java
+++ b/src/main/java/com/sendback/domain/scrap/controller/ScrapController.java
@@ -1,6 +1,6 @@
 package com.sendback.domain.scrap.controller;
 
-import com.sendback.domain.scrap.dto.response.ClickScrapResponse;
+import com.sendback.domain.scrap.dto.response.ClickScrapResponseDto;
 import com.sendback.domain.scrap.service.ScrapService;
 import com.sendback.global.common.ApiResponse;
 import com.sendback.global.common.UserId;
@@ -20,7 +20,7 @@ public class ScrapController {
     private final ScrapService scrapService;
 
     @PutMapping("/{projectId}/scrap")
-    public ApiResponse<ClickScrapResponse> reactLike(
+    public ApiResponse<ClickScrapResponseDto> reactLike(
             @UserId Long userId,
             @PathVariable Long projectId) {
         return success(scrapService.click(userId, projectId));

--- a/src/main/java/com/sendback/domain/scrap/dto/response/ClickScrapResponse.java
+++ b/src/main/java/com/sendback/domain/scrap/dto/response/ClickScrapResponse.java
@@ -1,3 +1,0 @@
-package com.sendback.domain.scrap.dto.response;
-
-public record ClickScrapResponse(boolean isClicked) {}

--- a/src/main/java/com/sendback/domain/scrap/dto/response/ClickScrapResponseDto.java
+++ b/src/main/java/com/sendback/domain/scrap/dto/response/ClickScrapResponseDto.java
@@ -1,0 +1,3 @@
+package com.sendback.domain.scrap.dto.response;
+
+public record ClickScrapResponseDto(boolean isClicked) {}

--- a/src/main/java/com/sendback/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/sendback/domain/scrap/service/ScrapService.java
@@ -2,7 +2,7 @@ package com.sendback.domain.scrap.service;
 
 import com.sendback.domain.project.entity.Project;
 import com.sendback.domain.project.service.ProjectService;
-import com.sendback.domain.scrap.dto.response.ClickScrapResponse;
+import com.sendback.domain.scrap.dto.response.ClickScrapResponseDto;
 import com.sendback.domain.scrap.entity.Scrap;
 import com.sendback.domain.scrap.repository.ScrapRepository;
 import com.sendback.domain.user.entity.User;
@@ -23,13 +23,13 @@ public class ScrapService {
     private final ScrapRepository scrapRepository;
 
     @Transactional
-    public ClickScrapResponse click(Long userId, Long projectId) {
+    public ClickScrapResponseDto click(Long userId, Long projectId) {
         User loginUser = userService.getUserById(userId);
         Project project = projectService.getProjectById(projectId);
 
         Scrap scrap = clickScrap(loginUser, project);
 
-        return new ClickScrapResponse(!scrap.isDeleted());
+        return new ClickScrapResponseDto(!scrap.isDeleted());
     }
 
     private Scrap clickScrap(User user, Project project) {

--- a/src/main/java/com/sendback/domain/user/entity/User.java
+++ b/src/main/java/com/sendback/domain/user/entity/User.java
@@ -57,4 +57,8 @@ public class User extends BaseEntity {
                 .profileImageUrl(profileImageUrl)
                 .build();
     }
+
+    public void levelUp(Level level) {
+        this.level = level;
+    }
 }

--- a/src/main/java/com/sendback/global/common/constants/Level.java
+++ b/src/main/java/com/sendback/global/common/constants/Level.java
@@ -4,10 +4,49 @@ import lombok.Getter;
 
 @Getter
 public enum Level {
-    ONE("ONE"), TWO("TWO"), THREE("THREE"), FOUR("FOUR"), FIVE("FIVE");
-    private final String level;
+    ONE("주먹밥", 0L),
+    TWO("솜주먹", 5L),
+    THREE("물주먹", 10L),
+    FOUR("돌주먹", 15L),
+    FIVE("불주먹", 20L);
+    private final String name;
+    private final Long feedbackSubmitCount;
 
-    Level(String level){
-        this.level = level;
+    Level(String name, Long feedbackSubmitCount){
+        this.name = name;
+        this.feedbackSubmitCount = feedbackSubmitCount;
+    }
+
+    public static Level getLevelByFeedbackSubmitCount(Long feedbackSubmitCount) {
+        if (TWO.feedbackSubmitCount > feedbackSubmitCount) {
+            return ONE;
+        }
+        else if (THREE.feedbackSubmitCount > feedbackSubmitCount) {
+            return TWO;
+        }
+        else if (FOUR.feedbackSubmitCount > feedbackSubmitCount) {
+            return THREE;
+        }
+        else if (FIVE.feedbackSubmitCount > feedbackSubmitCount) {
+            return FOUR;
+        }
+        else {
+            return FIVE;
+        }
+    }
+
+    public static Long getRemainCountUntilNextLevel(Long feedbackSubmitCount) {
+        if (TWO.feedbackSubmitCount > feedbackSubmitCount) {
+            return TWO.feedbackSubmitCount - feedbackSubmitCount;
+        }
+        else if (THREE.feedbackSubmitCount > feedbackSubmitCount) {
+            return THREE.feedbackSubmitCount - feedbackSubmitCount;
+        }
+        else if (FOUR.feedbackSubmitCount > feedbackSubmitCount) {
+            return FOUR.feedbackSubmitCount - feedbackSubmitCount;
+        }
+        else {
+            return FIVE.feedbackSubmitCount - feedbackSubmitCount;
+        }
     }
 }

--- a/src/main/java/com/sendback/global/config/auth/SecurityConfig.java
+++ b/src/main/java/com/sendback/global/config/auth/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.sendback.global.config.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -30,7 +31,11 @@ public class SecurityConfig {
             "/api/auth/google/callback",
             "/api/auth/reissue",
             "/",
-            "/docs/index.html"
+            "/docs/index.html",
+    };
+
+    private final String[] GET_METHOD_PERMITTED_URLS = {
+            "/api/projects/{projectId}/feedbacks/{feedbackId}"
     };
 
     @Bean
@@ -49,6 +54,7 @@ public class SecurityConfig {
                                 .accessDeniedHandler(jwtAccessDeniedHandler)
                 )
                 .authorizeHttpRequests((authorize) -> authorize
+                        .requestMatchers(HttpMethod.GET, GET_METHOD_PERMITTED_URLS).permitAll()
                         .requestMatchers(PERMITTED_URLS).permitAll()
                         .anyRequest().authenticated()
                 )
@@ -67,7 +73,7 @@ public class SecurityConfig {
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
         configuration.setAllowCredentials(true);
-        configuration.setAllowedOriginPatterns(Collections.singletonList("*"));;
+        configuration.setAllowedOriginPatterns(Collections.singletonList("*"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/com/sendback/global/config/image/S3SaveDir.java
+++ b/src/main/java/com/sendback/global/config/image/S3SaveDir.java
@@ -9,7 +9,8 @@ import static com.sendback.global.config.image.exception.ImageExceptionType.NOT_
 public enum S3SaveDir {
 
     USER("/user/profile"),
-    PROJECT("/project");
+    PROJECT("/project"),
+    FEEDBACK("/feedback");
 
     public final String path;
 
@@ -17,6 +18,7 @@ public enum S3SaveDir {
         return switch (stringParam.toLowerCase()) {
             case "user" -> USER;
             case "project" -> PROJECT;
+            case "feedback" -> FEEDBACK;
 
             default -> throw new ImageException(NOT_FOUND_IMAGE_PATH);
         };

--- a/src/main/java/com/sendback/global/config/image/service/ImageService.java
+++ b/src/main/java/com/sendback/global/config/image/service/ImageService.java
@@ -23,7 +23,7 @@ public class ImageService {
                 .toList();
     }
 
-    private String uploadImage(MultipartFile multipartFile, String type) {
+    public String uploadImage(MultipartFile multipartFile, String type) {
         S3SaveDir s3SaveDir = S3SaveDir.toEnum(type);
         //파일 타입에 따라 업로드 파일 경로 만들기
         String s3UploadFilePath = FilePathUtils.createS3UploadFilePath(multipartFile);

--- a/src/main/java/com/sendback/global/util/CustomDateUtil.java
+++ b/src/main/java/com/sendback/global/util/CustomDateUtil.java
@@ -1,0 +1,13 @@
+package com.sendback.global.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class CustomDateUtil {
+
+    public static final String DATE_FORMAT_YYYY_MM_DD_HH_MM = "yyyy-MM-dd HH:mm";
+
+    public static String customDateFormat(LocalDateTime localDateTime) {
+        return localDateTime.format(DateTimeFormatter.ofPattern(DATE_FORMAT_YYYY_MM_DD_HH_MM));
+    }
+}

--- a/src/test/java/com/sendback/domain/feedback/controller/FeedbackControllerTest.java
+++ b/src/test/java/com/sendback/domain/feedback/controller/FeedbackControllerTest.java
@@ -1,0 +1,227 @@
+package com.sendback.domain.feedback.controller;
+
+import com.sendback.domain.feedback.dto.request.SaveFeedbackRequest;
+import com.sendback.domain.feedback.dto.response.FeedbackDetailResponse;
+import com.sendback.domain.feedback.dto.response.FeedbackIdResponse;
+import com.sendback.domain.feedback.dto.response.SubmitFeedbackResponse;
+import com.sendback.global.ControllerTest;
+import com.sendback.global.WithMockCustomUser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static com.sendback.domain.feedback.fixture.FeedbackFixture.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class FeedbackControllerTest extends ControllerTest {
+
+    @Nested
+    @DisplayName("피드백 등록 시")
+    class saveFeedback {
+
+        SaveFeedbackRequest saveFeedbackRequest = MOCK_SAVE_FEEDBACK_REQUEST;
+
+        @Test
+        @WithMockCustomUser
+        @DisplayName("정상적인 요청이라면 성공을 반환한다.")
+        public void success() throws Exception {
+            //given
+            FeedbackIdResponse response = new FeedbackIdResponse(1L);
+            given(feedbackService.saveFeedback(anyLong(), anyLong(), any())).willReturn(response);
+
+            //when
+            ResultActions resultActions = mockMvc.perform(post("/api/projects/{projectId}/feedback", 1L)
+                            .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(saveFeedbackRequest)).with(csrf()))
+                    .andDo(print());
+
+            //then
+            resultActions
+                    .andDo(document("feedback/save",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            pathParameters(
+                                    parameterWithName("projectId").description("프로젝트 ID")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("JWT 엑세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
+                                    fieldWithPath("linkUrl").type(JsonFieldType.STRING).description("링크 주소"),
+                                    fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
+                                    fieldWithPath("rewardMessage").type(JsonFieldType.STRING).description("추가 리워드 문구"),
+                                    fieldWithPath("startedAt").type(JsonFieldType.STRING).description("시작 날짜"),
+                                    fieldWithPath("endedAt").type(JsonFieldType.STRING).description("끝나는 날짜")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                            .description("코드"),
+                                    fieldWithPath("data.feedbackId").type(JsonFieldType.NUMBER)
+                                            .description("피드백 ID"),
+                                    fieldWithPath("message").type(JsonFieldType.STRING)
+                                            .description("메시지")
+                            )))
+                    .andExpect(jsonPath("$.code").value("200"))
+                    .andExpect(jsonPath("$.message").value("성공"))
+                    .andExpect(jsonPath("$.data.feedbackId").value(1))
+                    .andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    @DisplayName("피드백 상세 조회 시")
+    class getFeedbackDetail {
+
+        FeedbackDetailResponse mockFeedbackDetailResponse = MOCK_FEEDBACK_DETAIL_RESPONSE;
+
+        @Test
+        @WithMockCustomUser
+        @DisplayName("정상적인 접근 시 성공을 반환한다.")
+        public void success() throws Exception {
+            //given
+            Long projectId = 1L;
+            Long feedbackId = 1L;
+            given(feedbackService.getFeedbackDetail(anyLong(), anyLong())).willReturn(mockFeedbackDetailResponse);
+
+            //when
+            ResultActions resultActions = mockMvc.perform(get("/api/projects/{projectId}/feedbacks/{feedbackId}", projectId, feedbackId).with(csrf()))
+                    .andDo(print());
+
+            //then
+            resultActions
+                    .andDo(document("feedback/detail",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            pathParameters(
+                                    parameterWithName("projectId").description("프로젝트 ID"),
+                                    parameterWithName("feedbackId").description("피드백 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                            .description("코드"),
+                                    fieldWithPath("data.userId").type(JsonFieldType.NUMBER).description("유저 ID"),
+                                    fieldWithPath("data.username").type(JsonFieldType.STRING).description("유저 이름"),
+                                    fieldWithPath("data.userLevel").type(JsonFieldType.STRING).description("유저 레벨"),
+                                    fieldWithPath("data.profileImageUrl").type(JsonFieldType.STRING).description("프로필 이미지 주소"),
+                                    fieldWithPath("data.feedbackId").type(JsonFieldType.NUMBER).description("피드백 ID"),
+                                    fieldWithPath("data.feedbackTitle").type(JsonFieldType.STRING).description("피드백 제목"),
+                                    fieldWithPath("data.linkUrl").type(JsonFieldType.STRING).description("피드백 링크"),
+                                    fieldWithPath("data.content").type(JsonFieldType.STRING).description("피드백 내용"),
+                                    fieldWithPath("data.rewardMessage").type(JsonFieldType.STRING).description("피드백 추가 리워드"),
+                                    fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("생성 날짜(날짜,시, 분까지)"),
+                                    fieldWithPath("data.startedAt").type(JsonFieldType.STRING).description("시작 날짜"),
+                                    fieldWithPath("data.endedAt").type(JsonFieldType.STRING).description("끝나는 날짜"),
+                                    fieldWithPath("data.projectId").type(JsonFieldType.NUMBER).description("프로젝트 ID"),
+                                    fieldWithPath("data.projectTitle").type(JsonFieldType.STRING).description("프로젝트 제목"),
+                                    fieldWithPath("data.field").type(JsonFieldType.STRING).description("분야"),
+                                    fieldWithPath("data.progress").type(JsonFieldType.STRING).description("진행 정도"),
+                                    fieldWithPath("message").type(JsonFieldType.STRING)
+                                            .description("메시지")
+                            )))
+                    .andExpect(jsonPath("$.code").value("200"))
+                    .andExpect(jsonPath("$.message").value("성공"))
+                    .andExpect(jsonPath("$.data.username").value(mockFeedbackDetailResponse.username()))
+                    .andExpect(jsonPath("$.data.userLevel").value(mockFeedbackDetailResponse.userLevel()))
+                    .andExpect(jsonPath("$.data.profileImageUrl").value(mockFeedbackDetailResponse.profileImageUrl()))
+                    .andExpect(jsonPath("$.data.feedbackId").value(mockFeedbackDetailResponse.feedbackId()))
+                    .andExpect(jsonPath("$.data.feedbackTitle").value(mockFeedbackDetailResponse.feedbackTitle()))
+                    .andExpect(jsonPath("$.data.linkUrl").value(mockFeedbackDetailResponse.linkUrl()))
+                    .andExpect(jsonPath("$.data.content").value(mockFeedbackDetailResponse.content()))
+                    .andExpect(jsonPath("$.data.rewardMessage").value(mockFeedbackDetailResponse.rewardMessage()))
+                    .andExpect(jsonPath("$.data.createdAt").value(mockFeedbackDetailResponse.createdAt()))
+                    .andExpect(jsonPath("$.data.startedAt").value(mockFeedbackDetailResponse.startedAt()))
+                    .andExpect(jsonPath("$.data.endedAt").value(mockFeedbackDetailResponse.endedAt()))
+                    .andExpect(jsonPath("$.data.projectId").value(mockFeedbackDetailResponse.projectId()))
+                    .andExpect(jsonPath("$.data.projectTitle").value(mockFeedbackDetailResponse.projectTitle()))
+                    .andExpect(jsonPath("$.data.field").value(mockFeedbackDetailResponse.field()))
+                    .andExpect(jsonPath("$.data.progress").value(mockFeedbackDetailResponse.progress()))
+                    .andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    @DisplayName("피드백을 제출 시")
+    class submitFeedback {
+
+        SubmitFeedbackResponse submitFeedbackResponse = MOCK_SUBMIT_FEEDBACK_RESPONSE;
+        @Test
+        @WithMockCustomUser
+        @DisplayName("정상적인 요청이면 성공을 반환한다.")
+        public void success() throws Exception {
+            //given
+            Long projectId = 1L;
+            Long feedbackId = 1L;
+
+            MockMultipartFile mockMultipartFile = new MockMultipartFile(
+                    "image",
+                    "피드백 스크린 샷",
+                    MediaType.IMAGE_JPEG_VALUE,
+                    "mock image".getBytes()
+            );
+
+            given(feedbackService.submitFeedback(anyLong(), anyLong(), any())).willReturn(submitFeedbackResponse);
+
+
+            //when
+            ResultActions resultActions = mockMvc.perform(multipart("/api/projects/{projectId}/feedbacks/{feedbackId}", projectId, feedbackId)
+                    .file(mockMultipartFile)
+                    .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken")
+                    .contentType(MediaType.MULTIPART_FORM_DATA).with(csrf()));
+            resultActions
+                    .andDo(print());
+
+            //then
+            resultActions
+                    .andDo(document("feedback/submit",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            pathParameters(
+                                    parameterWithName("projectId").description("프로젝트 ID"),
+                                    parameterWithName("feedbackId").description("피드백 ID")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("JWT 엑세스 토큰")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                            .description("코드"),
+                                    fieldWithPath("data.level").type(JsonFieldType.STRING).description("유저 레벨"),
+                                    fieldWithPath("data.isLevelUp").type(JsonFieldType.BOOLEAN).description("레벨업 했는지 여부"),
+                                    fieldWithPath("data.remainFeedbackCount").type(JsonFieldType.NUMBER).description("레벨업까지 남은 피드백 횟수"),
+                                    fieldWithPath("message").type(JsonFieldType.STRING)
+                                            .description("메시지")
+                            )))
+                    .andExpect(jsonPath("$.code").value("200"))
+                    .andExpect(jsonPath("$.message").value("성공"))
+                    .andExpect(jsonPath("$.data.level").value(submitFeedbackResponse.level()))
+                    .andExpect(jsonPath("$.data.isLevelUp").value(submitFeedbackResponse.isLevelUp()))
+                    .andExpect(jsonPath("$.data.remainFeedbackCount").value(submitFeedbackResponse.remainFeedbackCount()))
+                    .andExpect(status().isOk());
+
+
+        }
+    }
+}

--- a/src/test/java/com/sendback/domain/feedback/controller/FeedbackControllerTest.java
+++ b/src/test/java/com/sendback/domain/feedback/controller/FeedbackControllerTest.java
@@ -1,9 +1,9 @@
 package com.sendback.domain.feedback.controller;
 
-import com.sendback.domain.feedback.dto.request.SaveFeedbackRequest;
-import com.sendback.domain.feedback.dto.response.FeedbackDetailResponse;
-import com.sendback.domain.feedback.dto.response.FeedbackIdResponse;
-import com.sendback.domain.feedback.dto.response.SubmitFeedbackResponse;
+import com.sendback.domain.feedback.dto.request.SaveFeedbackRequestDto;
+import com.sendback.domain.feedback.dto.response.FeedbackDetailResponseDto;
+import com.sendback.domain.feedback.dto.response.FeedbackIdResponseDto;
+import com.sendback.domain.feedback.dto.response.SubmitFeedbackResponseDto;
 import com.sendback.global.ControllerTest;
 import com.sendback.global.WithMockCustomUser;
 import org.junit.jupiter.api.DisplayName;
@@ -40,21 +40,21 @@ public class FeedbackControllerTest extends ControllerTest {
     @DisplayName("피드백 등록 시")
     class saveFeedback {
 
-        SaveFeedbackRequest saveFeedbackRequest = MOCK_SAVE_FEEDBACK_REQUEST;
+        SaveFeedbackRequestDto saveFeedbackRequestDto = MOCK_SAVE_FEEDBACK_REQUEST;
 
         @Test
         @WithMockCustomUser
         @DisplayName("정상적인 요청이라면 성공을 반환한다.")
         public void success() throws Exception {
             //given
-            FeedbackIdResponse response = new FeedbackIdResponse(1L);
+            FeedbackIdResponseDto response = new FeedbackIdResponseDto(1L);
             given(feedbackService.saveFeedback(anyLong(), anyLong(), any())).willReturn(response);
 
             //when
             ResultActions resultActions = mockMvc.perform(post("/api/projects/{projectId}/feedback", 1L)
                             .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(saveFeedbackRequest)).with(csrf()))
+                            .content(objectMapper.writeValueAsString(saveFeedbackRequestDto)).with(csrf()))
                     .andDo(print());
 
             //then
@@ -95,7 +95,7 @@ public class FeedbackControllerTest extends ControllerTest {
     @DisplayName("피드백 상세 조회 시")
     class getFeedbackDetail {
 
-        FeedbackDetailResponse mockFeedbackDetailResponse = MOCK_FEEDBACK_DETAIL_RESPONSE;
+        FeedbackDetailResponseDto mockFeedbackDetailResponseDto = MOCK_FEEDBACK_DETAIL_RESPONSE;
 
         @Test
         @WithMockCustomUser
@@ -104,7 +104,7 @@ public class FeedbackControllerTest extends ControllerTest {
             //given
             Long projectId = 1L;
             Long feedbackId = 1L;
-            given(feedbackService.getFeedbackDetail(anyLong(), anyLong())).willReturn(mockFeedbackDetailResponse);
+            given(feedbackService.getFeedbackDetail(anyLong(), anyLong())).willReturn(mockFeedbackDetailResponseDto);
 
             //when
             ResultActions resultActions = mockMvc.perform(get("/api/projects/{projectId}/feedbacks/{feedbackId}", projectId, feedbackId).with(csrf()))
@@ -143,21 +143,21 @@ public class FeedbackControllerTest extends ControllerTest {
                             )))
                     .andExpect(jsonPath("$.code").value("200"))
                     .andExpect(jsonPath("$.message").value("성공"))
-                    .andExpect(jsonPath("$.data.username").value(mockFeedbackDetailResponse.username()))
-                    .andExpect(jsonPath("$.data.userLevel").value(mockFeedbackDetailResponse.userLevel()))
-                    .andExpect(jsonPath("$.data.profileImageUrl").value(mockFeedbackDetailResponse.profileImageUrl()))
-                    .andExpect(jsonPath("$.data.feedbackId").value(mockFeedbackDetailResponse.feedbackId()))
-                    .andExpect(jsonPath("$.data.feedbackTitle").value(mockFeedbackDetailResponse.feedbackTitle()))
-                    .andExpect(jsonPath("$.data.linkUrl").value(mockFeedbackDetailResponse.linkUrl()))
-                    .andExpect(jsonPath("$.data.content").value(mockFeedbackDetailResponse.content()))
-                    .andExpect(jsonPath("$.data.rewardMessage").value(mockFeedbackDetailResponse.rewardMessage()))
-                    .andExpect(jsonPath("$.data.createdAt").value(mockFeedbackDetailResponse.createdAt()))
-                    .andExpect(jsonPath("$.data.startedAt").value(mockFeedbackDetailResponse.startedAt()))
-                    .andExpect(jsonPath("$.data.endedAt").value(mockFeedbackDetailResponse.endedAt()))
-                    .andExpect(jsonPath("$.data.projectId").value(mockFeedbackDetailResponse.projectId()))
-                    .andExpect(jsonPath("$.data.projectTitle").value(mockFeedbackDetailResponse.projectTitle()))
-                    .andExpect(jsonPath("$.data.field").value(mockFeedbackDetailResponse.field()))
-                    .andExpect(jsonPath("$.data.progress").value(mockFeedbackDetailResponse.progress()))
+                    .andExpect(jsonPath("$.data.username").value(mockFeedbackDetailResponseDto.username()))
+                    .andExpect(jsonPath("$.data.userLevel").value(mockFeedbackDetailResponseDto.userLevel()))
+                    .andExpect(jsonPath("$.data.profileImageUrl").value(mockFeedbackDetailResponseDto.profileImageUrl()))
+                    .andExpect(jsonPath("$.data.feedbackId").value(mockFeedbackDetailResponseDto.feedbackId()))
+                    .andExpect(jsonPath("$.data.feedbackTitle").value(mockFeedbackDetailResponseDto.feedbackTitle()))
+                    .andExpect(jsonPath("$.data.linkUrl").value(mockFeedbackDetailResponseDto.linkUrl()))
+                    .andExpect(jsonPath("$.data.content").value(mockFeedbackDetailResponseDto.content()))
+                    .andExpect(jsonPath("$.data.rewardMessage").value(mockFeedbackDetailResponseDto.rewardMessage()))
+                    .andExpect(jsonPath("$.data.createdAt").value(mockFeedbackDetailResponseDto.createdAt()))
+                    .andExpect(jsonPath("$.data.startedAt").value(mockFeedbackDetailResponseDto.startedAt()))
+                    .andExpect(jsonPath("$.data.endedAt").value(mockFeedbackDetailResponseDto.endedAt()))
+                    .andExpect(jsonPath("$.data.projectId").value(mockFeedbackDetailResponseDto.projectId()))
+                    .andExpect(jsonPath("$.data.projectTitle").value(mockFeedbackDetailResponseDto.projectTitle()))
+                    .andExpect(jsonPath("$.data.field").value(mockFeedbackDetailResponseDto.field()))
+                    .andExpect(jsonPath("$.data.progress").value(mockFeedbackDetailResponseDto.progress()))
                     .andExpect(status().isOk());
         }
     }
@@ -166,7 +166,7 @@ public class FeedbackControllerTest extends ControllerTest {
     @DisplayName("피드백을 제출 시")
     class submitFeedback {
 
-        SubmitFeedbackResponse submitFeedbackResponse = MOCK_SUBMIT_FEEDBACK_RESPONSE;
+        SubmitFeedbackResponseDto submitFeedbackResponseDto = MOCK_SUBMIT_FEEDBACK_RESPONSE;
         @Test
         @WithMockCustomUser
         @DisplayName("정상적인 요청이면 성공을 반환한다.")
@@ -182,7 +182,7 @@ public class FeedbackControllerTest extends ControllerTest {
                     "mock image".getBytes()
             );
 
-            given(feedbackService.submitFeedback(anyLong(), anyLong(), any())).willReturn(submitFeedbackResponse);
+            given(feedbackService.submitFeedback(anyLong(), anyLong(), any())).willReturn(submitFeedbackResponseDto);
 
 
             //when
@@ -216,9 +216,9 @@ public class FeedbackControllerTest extends ControllerTest {
                             )))
                     .andExpect(jsonPath("$.code").value("200"))
                     .andExpect(jsonPath("$.message").value("성공"))
-                    .andExpect(jsonPath("$.data.level").value(submitFeedbackResponse.level()))
-                    .andExpect(jsonPath("$.data.isLevelUp").value(submitFeedbackResponse.isLevelUp()))
-                    .andExpect(jsonPath("$.data.remainFeedbackCount").value(submitFeedbackResponse.remainFeedbackCount()))
+                    .andExpect(jsonPath("$.data.level").value(submitFeedbackResponseDto.level()))
+                    .andExpect(jsonPath("$.data.isLevelUp").value(submitFeedbackResponseDto.isLevelUp()))
+                    .andExpect(jsonPath("$.data.remainFeedbackCount").value(submitFeedbackResponseDto.remainFeedbackCount()))
                     .andExpect(status().isOk());
 
 

--- a/src/test/java/com/sendback/domain/feedback/fixture/FeedbackFixture.java
+++ b/src/test/java/com/sendback/domain/feedback/fixture/FeedbackFixture.java
@@ -1,8 +1,8 @@
 package com.sendback.domain.feedback.fixture;
 
-import com.sendback.domain.feedback.dto.request.SaveFeedbackRequest;
-import com.sendback.domain.feedback.dto.response.FeedbackDetailResponse;
-import com.sendback.domain.feedback.dto.response.SubmitFeedbackResponse;
+import com.sendback.domain.feedback.dto.request.SaveFeedbackRequestDto;
+import com.sendback.domain.feedback.dto.response.FeedbackDetailResponseDto;
+import com.sendback.domain.feedback.dto.response.SubmitFeedbackResponseDto;
 import com.sendback.domain.feedback.entity.Feedback;
 import com.sendback.domain.feedback.entity.FeedbackSubmit;
 import com.sendback.domain.project.entity.Project;
@@ -21,15 +21,15 @@ public class FeedbackFixture {
     private static final LocalDate ENDED_AT = LocalDate.of(2024, 1, 5);
     private static final String SCREEN_SHOT_URL = "screenShotUrl";
 
-    public static final SaveFeedbackRequest MOCK_SAVE_FEEDBACK_REQUEST = new SaveFeedbackRequest(
+    public static final SaveFeedbackRequestDto MOCK_SAVE_FEEDBACK_REQUEST = new SaveFeedbackRequestDto(
             TITLE, LINK_URL, CONTENT, REWARD_MESSAGE, STARTED_AT, ENDED_AT);
 
-    public static final FeedbackDetailResponse MOCK_FEEDBACK_DETAIL_RESPONSE = new FeedbackDetailResponse(
+    public static final FeedbackDetailResponseDto MOCK_FEEDBACK_DETAIL_RESPONSE = new FeedbackDetailResponseDto(
             1L, "유저 닉네임", Level.ONE.getName(), "프로필 이미지 url", 1L, "피드백 제목", "피드백 링크",
             "피드백 내용", "추가 리워드 메시지", "yyyy-MM-dd HH:mm", LocalDate.of(2024, 1, 12).toString(),
             LocalDate.of(2024, 1, 15).toString(),1L, "프로젝트 ID", "art", "PLANNING");
 
-    public static final SubmitFeedbackResponse MOCK_SUBMIT_FEEDBACK_RESPONSE = new SubmitFeedbackResponse(
+    public static final SubmitFeedbackResponseDto MOCK_SUBMIT_FEEDBACK_RESPONSE = new SubmitFeedbackResponseDto(
             Level.ONE.getName(), false, 4L);
 
     public static FeedbackSubmit createDummyFeedbackSubmit(User user, Feedback feedback) {

--- a/src/test/java/com/sendback/domain/feedback/fixture/FeedbackFixture.java
+++ b/src/test/java/com/sendback/domain/feedback/fixture/FeedbackFixture.java
@@ -1,0 +1,43 @@
+package com.sendback.domain.feedback.fixture;
+
+import com.sendback.domain.feedback.dto.request.SaveFeedbackRequest;
+import com.sendback.domain.feedback.dto.response.FeedbackDetailResponse;
+import com.sendback.domain.feedback.dto.response.SubmitFeedbackResponse;
+import com.sendback.domain.feedback.entity.Feedback;
+import com.sendback.domain.feedback.entity.FeedbackSubmit;
+import com.sendback.domain.project.entity.Project;
+import com.sendback.domain.user.entity.User;
+import com.sendback.global.common.constants.Level;
+
+import java.time.LocalDate;
+
+public class FeedbackFixture {
+
+    private static final String TITLE = "title";
+    private static final String LINK_URL = "linkUrl";
+    private static final String CONTENT = "content";
+    private static final String REWARD_MESSAGE = "rewardMessage";
+    private static final LocalDate STARTED_AT = LocalDate.of(2024, 1, 1);
+    private static final LocalDate ENDED_AT = LocalDate.of(2024, 1, 5);
+    private static final String SCREEN_SHOT_URL = "screenShotUrl";
+
+    public static final SaveFeedbackRequest MOCK_SAVE_FEEDBACK_REQUEST = new SaveFeedbackRequest(
+            TITLE, LINK_URL, CONTENT, REWARD_MESSAGE, STARTED_AT, ENDED_AT);
+
+    public static final FeedbackDetailResponse MOCK_FEEDBACK_DETAIL_RESPONSE = new FeedbackDetailResponse(
+            1L, "유저 닉네임", Level.ONE.getName(), "프로필 이미지 url", 1L, "피드백 제목", "피드백 링크",
+            "피드백 내용", "추가 리워드 메시지", "yyyy-MM-dd HH:mm", LocalDate.of(2024, 1, 12).toString(),
+            LocalDate.of(2024, 1, 15).toString(),1L, "프로젝트 ID", "art", "PLANNING");
+
+    public static final SubmitFeedbackResponse MOCK_SUBMIT_FEEDBACK_RESPONSE = new SubmitFeedbackResponse(
+            Level.ONE.getName(), false, 4L);
+
+    public static FeedbackSubmit createDummyFeedbackSubmit(User user, Feedback feedback) {
+        return FeedbackSubmit.of(user, feedback, SCREEN_SHOT_URL);
+    }
+
+    public static Feedback createDummyFeedback(User user, Project project) {
+        return Feedback.of(user, project, MOCK_SAVE_FEEDBACK_REQUEST);
+    }
+
+}

--- a/src/test/java/com/sendback/domain/feedback/persister/FeedbackSubmitTestPersister.java
+++ b/src/test/java/com/sendback/domain/feedback/persister/FeedbackSubmitTestPersister.java
@@ -1,0 +1,46 @@
+package com.sendback.domain.feedback.persister;
+
+import com.sendback.domain.feedback.entity.Feedback;
+import com.sendback.domain.feedback.entity.FeedbackSubmit;
+import com.sendback.domain.feedback.repository.FeedbackSubmitRepository;
+import com.sendback.domain.user.entity.User;
+import com.sendback.domain.user.persister.UserTestPersister;
+import com.sendback.global.Persister;
+import lombok.RequiredArgsConstructor;
+import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
+
+@RequiredArgsConstructor
+@Persister
+public class FeedbackSubmitTestPersister {
+
+    private final UserTestPersister userTestPersister;
+    private final FeedbackTestPersister feedbackTestPersister;
+    private final FeedbackSubmitRepository feedbackSubmitRepository;
+
+    private User user;
+    private Feedback feedback;
+    private String screenShotUrl;
+
+    public FeedbackSubmitTestPersister user(User user) {
+        this.user = user;
+        return this;
+    }
+
+    public FeedbackSubmitTestPersister feedback(Feedback feedback) {
+        this.feedback = feedback;
+        return this;
+    }
+
+    public FeedbackSubmitTestPersister screenShotUrl(String screenShotUrl) {
+        this.screenShotUrl = screenShotUrl;
+        return this;
+    }
+
+    public FeedbackSubmit save() {
+        FeedbackSubmit feedbackSubmit = FeedbackSubmit.of(
+                (user == null ? userTestPersister.save() : user),
+                (feedback == null ? feedbackTestPersister.save() : feedback),
+                (screenShotUrl == null ? RandomStringUtils.random(10, true, true) : screenShotUrl));
+        return feedbackSubmitRepository.save(feedbackSubmit);
+    }
+}

--- a/src/test/java/com/sendback/domain/feedback/persister/FeedbackTestPersister.java
+++ b/src/test/java/com/sendback/domain/feedback/persister/FeedbackTestPersister.java
@@ -1,6 +1,6 @@
 package com.sendback.domain.feedback.persister;
 
-import com.sendback.domain.feedback.dto.request.SaveFeedbackRequest;
+import com.sendback.domain.feedback.dto.request.SaveFeedbackRequestDto;
 import com.sendback.domain.feedback.entity.Feedback;
 import com.sendback.domain.feedback.repository.FeedbackRepository;
 import com.sendback.domain.project.entity.Project;
@@ -23,7 +23,7 @@ public class FeedbackTestPersister {
     private User user;
     private Project project;
 
-    private SaveFeedbackRequest saveFeedbackRequest;
+    private SaveFeedbackRequestDto saveFeedbackRequestDto;
 
     public FeedbackTestPersister user(User user) {
         this.user = user;
@@ -35,8 +35,8 @@ public class FeedbackTestPersister {
         return this;
     }
 
-    public FeedbackTestPersister saveFeedbackRequest(SaveFeedbackRequest saveFeedbackRequest) {
-        this.saveFeedbackRequest = saveFeedbackRequest;
+    public FeedbackTestPersister saveFeedbackRequestDto(SaveFeedbackRequestDto saveFeedbackRequestDto) {
+        this.saveFeedbackRequestDto = saveFeedbackRequestDto;
         return this;
     }
 
@@ -44,7 +44,7 @@ public class FeedbackTestPersister {
         Feedback feedback = Feedback.of(
                 (user == null ? userTestPersister.save() : user),
                 (project == null ? projectTestPersister.save() : project),
-                (saveFeedbackRequest == null) ? MOCK_SAVE_FEEDBACK_REQUEST : saveFeedbackRequest
+                (saveFeedbackRequestDto == null) ? MOCK_SAVE_FEEDBACK_REQUEST : saveFeedbackRequestDto
         );
         return feedbackRepository.save(feedback);
     }

--- a/src/test/java/com/sendback/domain/feedback/persister/FeedbackTestPersister.java
+++ b/src/test/java/com/sendback/domain/feedback/persister/FeedbackTestPersister.java
@@ -1,0 +1,51 @@
+package com.sendback.domain.feedback.persister;
+
+import com.sendback.domain.feedback.dto.request.SaveFeedbackRequest;
+import com.sendback.domain.feedback.entity.Feedback;
+import com.sendback.domain.feedback.repository.FeedbackRepository;
+import com.sendback.domain.project.entity.Project;
+import com.sendback.domain.project.persister.ProjectTestPersister;
+import com.sendback.domain.user.entity.User;
+import com.sendback.domain.user.persister.UserTestPersister;
+import com.sendback.global.Persister;
+import lombok.RequiredArgsConstructor;
+
+import static com.sendback.domain.feedback.fixture.FeedbackFixture.MOCK_SAVE_FEEDBACK_REQUEST;
+
+@RequiredArgsConstructor
+@Persister
+public class FeedbackTestPersister {
+
+    private final UserTestPersister userTestPersister;
+    private final ProjectTestPersister projectTestPersister;
+    private final FeedbackRepository feedbackRepository;
+
+    private User user;
+    private Project project;
+
+    private SaveFeedbackRequest saveFeedbackRequest;
+
+    public FeedbackTestPersister user(User user) {
+        this.user = user;
+        return this;
+    }
+
+    public FeedbackTestPersister project(Project project) {
+        this.project = project;
+        return this;
+    }
+
+    public FeedbackTestPersister saveFeedbackRequest(SaveFeedbackRequest saveFeedbackRequest) {
+        this.saveFeedbackRequest = saveFeedbackRequest;
+        return this;
+    }
+
+    public Feedback save() {
+        Feedback feedback = Feedback.of(
+                (user == null ? userTestPersister.save() : user),
+                (project == null ? projectTestPersister.save() : project),
+                (saveFeedbackRequest == null) ? MOCK_SAVE_FEEDBACK_REQUEST : saveFeedbackRequest
+        );
+        return feedbackRepository.save(feedback);
+    }
+}

--- a/src/test/java/com/sendback/domain/feedback/repository/FeedbackSubmitRepositoryTest.java
+++ b/src/test/java/com/sendback/domain/feedback/repository/FeedbackSubmitRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.sendback.domain.feedback.repository;
+
+import com.sendback.domain.feedback.entity.FeedbackSubmit;
+import com.sendback.global.RepositoryTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class FeedbackSubmitRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    FeedbackSubmitRepository feedbackSubmitRepository;
+
+    @Nested
+    @DisplayName("user와 feedback으로 삭제되지 않은 피드백 제출이 있는 지 조회했을 때")
+    class existsByUserAndFeedbackAndIsDeletedIsFalse {
+
+        @Test
+        @DisplayName("값이 있으면 true를 반환한다.")
+        public void success_true() throws Exception {
+            //given
+            FeedbackSubmit feedbackSubmit = feedbackSubmitTestPersister.save();
+
+            //when
+            boolean exists = feedbackSubmitRepository.existsByUserAndFeedbackAndIsDeletedIsFalse(feedbackSubmit.getUser(), feedbackSubmit.getFeedback());
+
+            //then
+            assertThat(exists).isTrue();
+
+        }
+
+        @Test
+        @DisplayName("삭제된 값이 있으면 false를 반환한다.")
+        public void success_false() throws Exception {
+            //given
+            FeedbackSubmit feedbackSubmit = feedbackSubmitTestPersister.save();
+            feedbackSubmitRepository.delete(feedbackSubmit);
+
+            //when
+            boolean exists = feedbackSubmitRepository.existsByUserAndFeedbackAndIsDeletedIsFalse(feedbackSubmit.getUser(), feedbackSubmit.getFeedback());
+
+            //then
+            assertThat(exists).isFalse();
+
+        }
+    }
+
+}

--- a/src/test/java/com/sendback/domain/feedback/service/FeedbackServiceTest.java
+++ b/src/test/java/com/sendback/domain/feedback/service/FeedbackServiceTest.java
@@ -1,0 +1,207 @@
+package com.sendback.domain.feedback.service;
+
+import com.sendback.domain.feedback.dto.request.SaveFeedbackRequest;
+import com.sendback.domain.feedback.dto.response.FeedbackDetailResponse;
+import com.sendback.domain.feedback.dto.response.FeedbackIdResponse;
+import com.sendback.domain.feedback.dto.response.SubmitFeedbackResponse;
+import com.sendback.domain.feedback.entity.Feedback;
+import com.sendback.domain.feedback.entity.FeedbackSubmit;
+import com.sendback.domain.feedback.repository.FeedbackRepository;
+import com.sendback.domain.feedback.repository.FeedbackSubmitRepository;
+import com.sendback.domain.project.entity.Project;
+import com.sendback.domain.project.service.ProjectService;
+import com.sendback.domain.user.entity.User;
+import com.sendback.domain.user.service.UserService;
+import com.sendback.global.ServiceTest;
+import com.sendback.global.common.constants.Level;
+import com.sendback.global.config.image.service.ImageService;
+import com.sendback.global.exception.type.BadRequestException;
+import com.sendback.global.exception.type.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static com.sendback.domain.feedback.exception.FeedbackExceptionType.DUPLICATE_FEEDBACK_SUBMIT;
+import static com.sendback.domain.feedback.exception.FeedbackExceptionType.NOT_FOUND_FEEDBACK;
+import static com.sendback.domain.feedback.fixture.FeedbackFixture.*;
+import static com.sendback.domain.project.exception.ProjectExceptionType.NOT_PROJECT_AUTHOR;
+import static com.sendback.domain.project.fixture.ProjectFixture.createDummyProject;
+import static com.sendback.domain.user.fixture.UserFixture.createDummyUser;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+public class FeedbackServiceTest extends ServiceTest {
+
+    @InjectMocks
+    FeedbackService feedbackService;
+
+    @Mock
+    UserService userService;
+    @Mock
+    ProjectService projectService;
+    @Mock
+    ImageService imageService;
+    @Mock
+    FeedbackRepository feedbackRepository;
+    @Mock
+    FeedbackSubmitRepository feedbackSubmitRepository;
+
+    private User user = createDummyUser();
+    private Project project = createDummyProject(user);
+    private Feedback feedback = createDummyFeedback(user, project);
+    private final FeedbackSubmit feedbackSubmit = createDummyFeedbackSubmit(user, feedback);
+
+    private final SaveFeedbackRequest saveFeedbackRequest = MOCK_SAVE_FEEDBACK_REQUEST;
+
+    @BeforeEach
+    public void setUp() {
+        this.user = spy(createDummyUser());
+        this.project = spy(createDummyProject(user));
+        this.feedback = spy(createDummyFeedback(user, project));
+    }
+
+    @Nested
+    @DisplayName("피드백 등록 시")
+    class saveFeedback {
+
+        @Test
+        @DisplayName("프로젝트 작성자와 같지 않으면 예외를 발생한다.")
+        public void fail_notAuthor() throws Exception {
+            //given
+            given(userService.getUserById(anyLong())).willReturn(user);
+            given(projectService.getProjectById(anyLong())).willReturn(project);
+            doThrow(new BadRequestException(NOT_PROJECT_AUTHOR)).when(projectService).validateProjectAuthor(any(User.class), any(Project.class));
+
+            //when - then
+            assertThatThrownBy(() -> feedbackService.saveFeedback(1L, 1L, saveFeedbackRequest))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage(NOT_PROJECT_AUTHOR.getMessage());
+        }
+
+        @Test
+        @DisplayName("정상적인 요청일 시 피드백을 저장한다.")
+        public void success() throws Exception {
+            //given
+            given(userService.getUserById(anyLong())).willReturn(user);
+            given(projectService.getProjectById(anyLong())).willReturn(project);
+            doNothing().when(projectService).validateProjectAuthor(any(User.class), any(Project.class));
+            given(feedbackRepository.save(any(Feedback.class))).willReturn(feedback);
+            given(feedback.getId()).willReturn(1L);
+
+            //when
+            FeedbackIdResponse feedbackIdResponse = feedbackService.saveFeedback(1L, 1L, saveFeedbackRequest);
+
+            //then
+            assertThat(feedbackIdResponse.feedbackId()).isEqualTo(1L);
+        }
+    }
+
+    @Nested
+    @DisplayName("피드백 상세 조회 시")
+    class getFeedbackDetail {
+
+        @Test
+        @DisplayName("존재하지 않는 피드백 ID이면 오류를 발생한다.")
+        public void fail_notExistFeedback() throws Exception {
+            //given
+            given(feedbackRepository.findById(anyLong())).willReturn(Optional.empty());
+
+            //when - then
+            assertThatThrownBy(() -> feedbackService.getFeedbackDetail(1L, 1L))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage(NOT_FOUND_FEEDBACK.getMessage());
+
+        }
+
+        @Test
+        @DisplayName("정상적인 요청일 시 값을 반환한다.")
+        public void success() throws Exception {
+            //given
+            given(projectService.getProjectById(anyLong())).willReturn(project);
+            given(feedbackRepository.findById(anyLong())).willReturn(Optional.of(feedback));
+            given(project.getUser()).willReturn(user);
+            given(user.getLevel()).willReturn(Level.ONE);
+            given(feedback.getCreatedAt()).willReturn(LocalDateTime.now());
+
+            //when
+            FeedbackDetailResponse feedbackDetailResponse = feedbackService.getFeedbackDetail(1L, 1L);
+
+            //then
+            assertThat(feedbackDetailResponse.feedbackTitle()).isEqualTo(feedback.getTitle());
+            assertThat(feedbackDetailResponse.username()).isEqualTo(feedback.getUser().getNickname());
+            assertThat(feedbackDetailResponse.projectTitle()).isEqualTo(feedback.getProject().getTitle());
+        }
+    }
+
+    @Nested
+    @DisplayName("피드백을 제출했을 때")
+    class submitFeedback {
+
+        @Test
+        @DisplayName("이미 제출했던 유저면 예외를 발생한다.")
+        public void fail_alreadySubmit() throws Exception {
+            //given
+            given(userService.getUserById(anyLong())).willReturn(user);
+            given(feedbackRepository.findById(anyLong())).willReturn(Optional.of(feedback));
+            given(feedbackSubmitRepository.existsByUserAndFeedbackAndIsDeletedIsFalse(any(User.class), any(Feedback.class))).willReturn(true);
+
+            //when - then
+            assertThatThrownBy(() -> feedbackService.submitFeedback(1L, 1L, mockingMultipartFile("screenShot")))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage(DUPLICATE_FEEDBACK_SUBMIT.getMessage());
+        }
+
+        @Test
+        @DisplayName("레벨업이 되지 않는 상태면 유저 레벨을 유지하고 값을 반환한다.")
+        public void success_keep() throws Exception {
+            //given
+            given(userService.getUserById(anyLong())).willReturn(user);
+            given(feedbackRepository.findById(anyLong())).willReturn(Optional.of(feedback));
+            given(feedbackSubmitRepository.existsByUserAndFeedbackAndIsDeletedIsFalse(any(User.class), any(Feedback.class))).willReturn(false);
+            given(imageService.uploadImage(any(), anyString())).willReturn("sendback1.jpg");
+            given(feedbackSubmitRepository.save(any(FeedbackSubmit.class))).willReturn(feedbackSubmit);
+            given(feedbackSubmitRepository.countByUserAndIsDeletedIsFalse(any(User.class))).willReturn(1L);
+            given(user.getLevel()).willReturn(Level.ONE);
+
+            //when
+            SubmitFeedbackResponse response = feedbackService.submitFeedback(1L, 1L, mockingMultipartFile("feedback"));
+
+            //then
+            assertThat(response.level()).isEqualTo(user.getLevel().getName());
+            assertThat(response.isLevelUp()).isFalse();
+            assertThat(response.remainFeedbackCount()).isEqualTo(4L);
+        }
+
+        @Test
+        @DisplayName("레벨업이 되지 않는 상태면 유저 레벨을 유지하고 값을 반환한다.")
+        public void success_levelUp() throws Exception {
+            //given
+            given(userService.getUserById(anyLong())).willReturn(user);
+            given(feedbackRepository.findById(anyLong())).willReturn(Optional.of(feedback));
+            given(feedbackSubmitRepository.existsByUserAndFeedbackAndIsDeletedIsFalse(any(User.class), any(Feedback.class))).willReturn(false);
+            given(imageService.uploadImage(any(), anyString())).willReturn("sendback1.jpg");
+            given(feedbackSubmitRepository.save(any(FeedbackSubmit.class))).willReturn(feedbackSubmit);
+            given(feedbackSubmitRepository.countByUserAndIsDeletedIsFalse(any(User.class))).willReturn(5L);
+            given(user.getLevel()).willReturn(Level.ONE).willReturn(Level.TWO);
+
+            //when
+            SubmitFeedbackResponse response = feedbackService.submitFeedback(1L, 1L, mockingMultipartFile("feedback"));
+
+            //then
+            assertThat(response.level()).isEqualTo(Level.TWO.getName());
+            assertThat(response.isLevelUp()).isTrue();
+            assertThat(response.remainFeedbackCount()).isEqualTo(5L);
+        }
+    }
+
+}

--- a/src/test/java/com/sendback/domain/feedback/service/FeedbackServiceTest.java
+++ b/src/test/java/com/sendback/domain/feedback/service/FeedbackServiceTest.java
@@ -1,9 +1,9 @@
 package com.sendback.domain.feedback.service;
 
-import com.sendback.domain.feedback.dto.request.SaveFeedbackRequest;
-import com.sendback.domain.feedback.dto.response.FeedbackDetailResponse;
-import com.sendback.domain.feedback.dto.response.FeedbackIdResponse;
-import com.sendback.domain.feedback.dto.response.SubmitFeedbackResponse;
+import com.sendback.domain.feedback.dto.request.SaveFeedbackRequestDto;
+import com.sendback.domain.feedback.dto.response.FeedbackDetailResponseDto;
+import com.sendback.domain.feedback.dto.response.FeedbackIdResponseDto;
+import com.sendback.domain.feedback.dto.response.SubmitFeedbackResponseDto;
 import com.sendback.domain.feedback.entity.Feedback;
 import com.sendback.domain.feedback.entity.FeedbackSubmit;
 import com.sendback.domain.feedback.repository.FeedbackRepository;
@@ -61,7 +61,7 @@ public class FeedbackServiceTest extends ServiceTest {
     private Feedback feedback = createDummyFeedback(user, project);
     private final FeedbackSubmit feedbackSubmit = createDummyFeedbackSubmit(user, feedback);
 
-    private final SaveFeedbackRequest saveFeedbackRequest = MOCK_SAVE_FEEDBACK_REQUEST;
+    private final SaveFeedbackRequestDto saveFeedbackRequestDto = MOCK_SAVE_FEEDBACK_REQUEST;
 
     @BeforeEach
     public void setUp() {
@@ -83,7 +83,7 @@ public class FeedbackServiceTest extends ServiceTest {
             doThrow(new BadRequestException(NOT_PROJECT_AUTHOR)).when(projectService).validateProjectAuthor(any(User.class), any(Project.class));
 
             //when - then
-            assertThatThrownBy(() -> feedbackService.saveFeedback(1L, 1L, saveFeedbackRequest))
+            assertThatThrownBy(() -> feedbackService.saveFeedback(1L, 1L, saveFeedbackRequestDto))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage(NOT_PROJECT_AUTHOR.getMessage());
         }
@@ -99,10 +99,10 @@ public class FeedbackServiceTest extends ServiceTest {
             given(feedback.getId()).willReturn(1L);
 
             //when
-            FeedbackIdResponse feedbackIdResponse = feedbackService.saveFeedback(1L, 1L, saveFeedbackRequest);
+            FeedbackIdResponseDto feedbackIdResponseDto = feedbackService.saveFeedback(1L, 1L, saveFeedbackRequestDto);
 
             //then
-            assertThat(feedbackIdResponse.feedbackId()).isEqualTo(1L);
+            assertThat(feedbackIdResponseDto.feedbackId()).isEqualTo(1L);
         }
     }
 
@@ -134,12 +134,12 @@ public class FeedbackServiceTest extends ServiceTest {
             given(feedback.getCreatedAt()).willReturn(LocalDateTime.now());
 
             //when
-            FeedbackDetailResponse feedbackDetailResponse = feedbackService.getFeedbackDetail(1L, 1L);
+            FeedbackDetailResponseDto feedbackDetailResponseDto = feedbackService.getFeedbackDetail(1L, 1L);
 
             //then
-            assertThat(feedbackDetailResponse.feedbackTitle()).isEqualTo(feedback.getTitle());
-            assertThat(feedbackDetailResponse.username()).isEqualTo(feedback.getUser().getNickname());
-            assertThat(feedbackDetailResponse.projectTitle()).isEqualTo(feedback.getProject().getTitle());
+            assertThat(feedbackDetailResponseDto.feedbackTitle()).isEqualTo(feedback.getTitle());
+            assertThat(feedbackDetailResponseDto.username()).isEqualTo(feedback.getUser().getNickname());
+            assertThat(feedbackDetailResponseDto.projectTitle()).isEqualTo(feedback.getProject().getTitle());
         }
     }
 
@@ -174,7 +174,7 @@ public class FeedbackServiceTest extends ServiceTest {
             given(user.getLevel()).willReturn(Level.ONE);
 
             //when
-            SubmitFeedbackResponse response = feedbackService.submitFeedback(1L, 1L, mockingMultipartFile("feedback"));
+            SubmitFeedbackResponseDto response = feedbackService.submitFeedback(1L, 1L, mockingMultipartFile("feedback"));
 
             //then
             assertThat(response.level()).isEqualTo(user.getLevel().getName());
@@ -195,7 +195,7 @@ public class FeedbackServiceTest extends ServiceTest {
             given(user.getLevel()).willReturn(Level.ONE).willReturn(Level.TWO);
 
             //when
-            SubmitFeedbackResponse response = feedbackService.submitFeedback(1L, 1L, mockingMultipartFile("feedback"));
+            SubmitFeedbackResponseDto response = feedbackService.submitFeedback(1L, 1L, mockingMultipartFile("feedback"));
 
             //then
             assertThat(response.level()).isEqualTo(Level.TWO.getName());

--- a/src/test/java/com/sendback/domain/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/sendback/domain/like/controller/LikeControllerTest.java
@@ -38,7 +38,7 @@ public class LikeControllerTest extends ControllerTest {
         //given
         Long projectId = 1L;
         ReactLikeResponseDto reactLikeResponseDto = new ReactLikeResponseDto(true);
-        given(likeService.react(anyLong(), anyLong())).willReturn(reactLikeResponseDto);
+        given(likeService.reactLike(anyLong(), anyLong())).willReturn(reactLikeResponseDto);
 
         //when
         ResultActions resultActions = mockMvc.perform(put("/api/projects/{projectId}/like", projectId)

--- a/src/test/java/com/sendback/domain/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/sendback/domain/like/controller/LikeControllerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -40,10 +41,13 @@ public class LikeControllerTest extends ControllerTest {
         given(likeService.react(anyLong(), anyLong())).willReturn(reactLikeResponse);
 
         //when
-        mockMvc.perform(put("/api/projects/{projectId}/like", projectId)
-                .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX+"AccessToken")
-                .accept(MediaType.APPLICATION_JSON).with(csrf()))
-                .andDo(print())
+        ResultActions resultActions = mockMvc.perform(put("/api/projects/{projectId}/like", projectId)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken")
+                        .accept(MediaType.APPLICATION_JSON).with(csrf()))
+                .andDo(print());
+
+        //then
+        resultActions
                 .andDo(document("like/react",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),

--- a/src/test/java/com/sendback/domain/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/sendback/domain/like/controller/LikeControllerTest.java
@@ -1,6 +1,6 @@
 package com.sendback.domain.like.controller;
 
-import com.sendback.domain.like.dto.response.ReactLikeResponse;
+import com.sendback.domain.like.dto.response.ReactLikeResponseDto;
 import com.sendback.global.ControllerTest;
 import com.sendback.global.WithMockCustomUser;
 import org.junit.jupiter.api.DisplayName;
@@ -37,8 +37,8 @@ public class LikeControllerTest extends ControllerTest {
     public void success() throws Exception {
         //given
         Long projectId = 1L;
-        ReactLikeResponse reactLikeResponse = new ReactLikeResponse(true);
-        given(likeService.react(anyLong(), anyLong())).willReturn(reactLikeResponse);
+        ReactLikeResponseDto reactLikeResponseDto = new ReactLikeResponseDto(true);
+        given(likeService.react(anyLong(), anyLong())).willReturn(reactLikeResponseDto);
 
         //when
         ResultActions resultActions = mockMvc.perform(put("/api/projects/{projectId}/like", projectId)

--- a/src/test/java/com/sendback/domain/like/service/LikeServiceTest.java
+++ b/src/test/java/com/sendback/domain/like/service/LikeServiceTest.java
@@ -66,7 +66,7 @@ public class LikeServiceTest extends ServiceTest {
             given(likeRepository.save(any(Like.class))).willReturn(like);
 
             //when
-            ReactLikeResponseDto reactLikeResponseDto = likeService.react(1L, 1L);
+            ReactLikeResponseDto reactLikeResponseDto = likeService.reactLike(1L, 1L);
 
             //then
             assertThat(reactLikeResponseDto.isReacted()).isTrue();
@@ -81,7 +81,7 @@ public class LikeServiceTest extends ServiceTest {
             given(likeRepository.findByUserAndProject(any(User.class), any(Project.class))).willReturn(Optional.of(like));
 
             //when
-            ReactLikeResponseDto reactLikeResponseDto = likeService.react(1L, 1L);
+            ReactLikeResponseDto reactLikeResponseDto = likeService.reactLike(1L, 1L);
 
             //then
             assertThat(reactLikeResponseDto.isReacted()).isFalse();

--- a/src/test/java/com/sendback/domain/like/service/LikeServiceTest.java
+++ b/src/test/java/com/sendback/domain/like/service/LikeServiceTest.java
@@ -1,6 +1,6 @@
 package com.sendback.domain.like.service;
 
-import com.sendback.domain.like.dto.response.ReactLikeResponse;
+import com.sendback.domain.like.dto.response.ReactLikeResponseDto;
 import com.sendback.domain.like.entity.Like;
 import com.sendback.domain.like.repository.LikeRepository;
 import com.sendback.domain.project.entity.Project;
@@ -66,10 +66,10 @@ public class LikeServiceTest extends ServiceTest {
             given(likeRepository.save(any(Like.class))).willReturn(like);
 
             //when
-            ReactLikeResponse reactLikeResponse = likeService.react(1L, 1L);
+            ReactLikeResponseDto reactLikeResponseDto = likeService.react(1L, 1L);
 
             //then
-            assertThat(reactLikeResponse.isReacted()).isTrue();
+            assertThat(reactLikeResponseDto.isReacted()).isTrue();
         }
 
         @Test
@@ -81,10 +81,10 @@ public class LikeServiceTest extends ServiceTest {
             given(likeRepository.findByUserAndProject(any(User.class), any(Project.class))).willReturn(Optional.of(like));
 
             //when
-            ReactLikeResponse reactLikeResponse = likeService.react(1L, 1L);
+            ReactLikeResponseDto reactLikeResponseDto = likeService.react(1L, 1L);
 
             //then
-            assertThat(reactLikeResponse.isReacted()).isFalse();
+            assertThat(reactLikeResponseDto.isReacted()).isFalse();
         }
 
         @Test
@@ -98,10 +98,10 @@ public class LikeServiceTest extends ServiceTest {
             given(likeRepository.findByUserAndProject(any(User.class), any(Project.class))).willReturn(Optional.of(like));
 
             //when
-            ReactLikeResponse reactLikeResponse = likeService.react(1L, 1L);
+            ReactLikeResponseDto reactLikeResponseDto = likeService.react(1L, 1L);
 
             //then
-            assertThat(reactLikeResponse.isReacted()).isTrue();
+            assertThat(reactLikeResponseDto.isReacted()).isTrue();
         }
     }
 }

--- a/src/test/java/com/sendback/domain/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/sendback/domain/project/controller/ProjectControllerTest.java
@@ -1,8 +1,8 @@
 package com.sendback.domain.project.controller;
 
-import com.sendback.domain.project.dto.request.SaveProjectRequest;
-import com.sendback.domain.project.dto.request.UpdateProjectRequest;
-import com.sendback.domain.project.dto.response.ProjectIdResponse;
+import com.sendback.domain.project.dto.request.SaveProjectRequestDto;
+import com.sendback.domain.project.dto.request.UpdateProjectRequestDto;
+import com.sendback.domain.project.dto.response.ProjectIdResponseDto;
 import com.sendback.global.ControllerTest;
 import com.sendback.global.WithMockCustomUser;
 import org.junit.jupiter.api.DisplayName;
@@ -15,8 +15,8 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
-import static com.sendback.domain.project.fixture.ProjectFixture.mock_saveProjectRequest;
-import static com.sendback.domain.project.fixture.ProjectFixture.mock_updateProjectRequest;
+import static com.sendback.domain.project.fixture.ProjectFixture.MOCK___SAVE_PROJECT_REQUEST_DTO;
+import static com.sendback.domain.project.fixture.ProjectFixture.MOCK___UPDATE_PROJECT_REQUEST_DTO;
 import static org.mockito.ArgumentMatchers.*;
 
 
@@ -43,7 +43,7 @@ public class ProjectControllerTest extends ControllerTest {
     @DisplayName("project 등록 요청 시")
     class saveProject {
 
-        SaveProjectRequest saveProjectRequest = mock_saveProjectRequest;
+        SaveProjectRequestDto saveProjectRequestDto = MOCK___SAVE_PROJECT_REQUEST_DTO;
         @Test
         @DisplayName("saveProjectRequest와 이미지들이 존재한다면 성공을 반환한다.")
         @WithMockCustomUser
@@ -53,9 +53,9 @@ public class ProjectControllerTest extends ControllerTest {
             MockMultipartFile second_multipartFile = mockingMultipartFile("second");
             MockMultipartFile data =
                     new MockMultipartFile("data", null, "application/json",
-                            objectMapper.writeValueAsString(saveProjectRequest).getBytes(StandardCharsets.UTF_8));
-            ProjectIdResponse projectIdResponse = new ProjectIdResponse(1L);
-            given(projectService.saveProject(anyLong(), any(SaveProjectRequest.class), anyList())).willReturn(projectIdResponse);
+                            objectMapper.writeValueAsString(saveProjectRequestDto).getBytes(StandardCharsets.UTF_8));
+            ProjectIdResponseDto projectIdResponseDto = new ProjectIdResponseDto(1L);
+            given(projectService.saveProject(anyLong(), any(SaveProjectRequestDto.class), anyList())).willReturn(projectIdResponseDto);
 
             //when
             ResultActions resultActions = mockMvc.perform(multipart("/api/projects")
@@ -115,9 +115,9 @@ public class ProjectControllerTest extends ControllerTest {
             //given
             MockMultipartFile data =
                     new MockMultipartFile("data", null, "application/json",
-                            objectMapper.writeValueAsString(saveProjectRequest).getBytes(StandardCharsets.UTF_8));
-            ProjectIdResponse projectIdResponse = new ProjectIdResponse(1L);
-            given(projectService.saveProject(anyLong(), any(SaveProjectRequest.class), any())).willReturn(projectIdResponse);
+                            objectMapper.writeValueAsString(saveProjectRequestDto).getBytes(StandardCharsets.UTF_8));
+            ProjectIdResponseDto projectIdResponseDto = new ProjectIdResponseDto(1L);
+            given(projectService.saveProject(anyLong(), any(SaveProjectRequestDto.class), any())).willReturn(projectIdResponseDto);
 
             //when
             mockMvc.perform(multipart("/api/projects")
@@ -161,7 +161,7 @@ public class ProjectControllerTest extends ControllerTest {
     @DisplayName("project 수정 요청 시")
     class updateProject {
 
-        UpdateProjectRequest updateProjectRequest = mock_updateProjectRequest;
+        UpdateProjectRequestDto updateProjectRequestDto = MOCK___UPDATE_PROJECT_REQUEST_DTO;
 
         @Test
         @DisplayName("updateProjectRequest와 이미지들이 존재한다면 성공을 반환한다.")
@@ -174,9 +174,9 @@ public class ProjectControllerTest extends ControllerTest {
             MockMultipartFile second_multipartFile = mockingMultipartFile("second");
             MockMultipartFile data =
                     new MockMultipartFile("data", null, "application/json",
-                            objectMapper.writeValueAsString(updateProjectRequest).getBytes(StandardCharsets.UTF_8));
-            ProjectIdResponse projectIdResponse = new ProjectIdResponse(projectId);
-            given(projectService.updateProject(anyLong(), anyLong(), any(UpdateProjectRequest.class), anyList())).willReturn(projectIdResponse);
+                            objectMapper.writeValueAsString(updateProjectRequestDto).getBytes(StandardCharsets.UTF_8));
+            ProjectIdResponseDto projectIdResponseDto = new ProjectIdResponseDto(projectId);
+            given(projectService.updateProject(anyLong(), anyLong(), any(UpdateProjectRequestDto.class), anyList())).willReturn(projectIdResponseDto);
 
             //when
             ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.

--- a/src/test/java/com/sendback/domain/project/fixture/ProjectFixture.java
+++ b/src/test/java/com/sendback/domain/project/fixture/ProjectFixture.java
@@ -1,8 +1,8 @@
 package com.sendback.domain.project.fixture;
 
 import com.sendback.domain.field.entity.Field;
-import com.sendback.domain.project.dto.request.SaveProjectRequest;
-import com.sendback.domain.project.dto.request.UpdateProjectRequest;
+import com.sendback.domain.project.dto.request.SaveProjectRequestDto;
+import com.sendback.domain.project.dto.request.UpdateProjectRequestDto;
 import com.sendback.global.common.constants.Progress;
 import com.sendback.domain.project.entity.Project;
 import com.sendback.domain.user.entity.User;
@@ -29,16 +29,16 @@ public class ProjectFixture {
     private static final Progress PLANNING_PROGRESS = Progress.PLANNING;
     private static final Progress DEVELOPING_PROGRESS = Progress.DEVELOPING;
 
-    public static final SaveProjectRequest mock_saveProjectRequest = new SaveProjectRequest(TITLE, FIELD, CONTENT, SUMMARY, DEMO_SITE_URL, START_DATE,
+    public static final SaveProjectRequestDto MOCK___SAVE_PROJECT_REQUEST_DTO = new SaveProjectRequestDto(TITLE, FIELD, CONTENT, SUMMARY, DEMO_SITE_URL, START_DATE,
             END_DATE, PLANNING_PROGRESS.toString(), 1L,2L,3L,4L);
 
-    public static final UpdateProjectRequest mock_updateProjectRequest = new UpdateProjectRequest(
+    public static final UpdateProjectRequestDto MOCK___UPDATE_PROJECT_REQUEST_DTO = new UpdateProjectRequestDto(
             UPDATE_TITLE, UPDATE_FIELD, UPDATE_CONTENT, UPDATE_SUMMARY, UPDATE_DEMO_SITE_URL, UPDATE_START_DATE, UPDATE_END_DATE, DEVELOPING_PROGRESS.toString(),
             4L, 3L, 2L, 1L, List.of("deleteUrl")
     );
 
     public static Project createDummyProject(User user) {
-        return Project.of(user, Field.of(FIELD), mock_saveProjectRequest);
+        return Project.of(user, Field.of(FIELD), MOCK___SAVE_PROJECT_REQUEST_DTO);
     }
 
 }

--- a/src/test/java/com/sendback/domain/project/persister/ProjectTestPersister.java
+++ b/src/test/java/com/sendback/domain/project/persister/ProjectTestPersister.java
@@ -2,7 +2,7 @@ package com.sendback.domain.project.persister;
 
 import com.sendback.domain.field.entity.Field;
 import com.sendback.domain.field.persister.FieldTestPersister;
-import com.sendback.domain.project.dto.request.SaveProjectRequest;
+import com.sendback.domain.project.dto.request.SaveProjectRequestDto;
 import com.sendback.global.common.constants.Progress;
 import com.sendback.domain.project.entity.Project;
 import com.sendback.domain.project.repository.ProjectRepository;
@@ -23,7 +23,7 @@ public class ProjectTestPersister {
 
     private User user;
     private Field field;
-    private SaveProjectRequest saveProjectRequest;
+    private SaveProjectRequestDto saveProjectRequestDto;
 
     public ProjectTestPersister user(User user) {
         this.user = user;
@@ -35,8 +35,8 @@ public class ProjectTestPersister {
         return this;
     }
 
-    public ProjectTestPersister saveProjectRequest(SaveProjectRequest saveProjectRequest) {
-        this.saveProjectRequest = saveProjectRequest;
+    public ProjectTestPersister saveProjectRequestDto(SaveProjectRequestDto saveProjectRequestDto) {
+        this.saveProjectRequestDto = saveProjectRequestDto;
         return this;
     }
 
@@ -53,8 +53,8 @@ public class ProjectTestPersister {
         Project project = Project.of(
                 (user == null ? userTestPersister.save() : user),
                 (field == null ? fieldTestPersister.save() : field),
-                (saveProjectRequest == null ? new SaveProjectRequest(TITLE, FIELD, CONTENT, SUMMARY, DEMO_SITE_URL, START_DATE, END_DATE,
-                        PLANNING_PROGRESS.toString(), 1L, 2L, 3L, 4L) : saveProjectRequest)
+                (saveProjectRequestDto == null ? new SaveProjectRequestDto(TITLE, FIELD, CONTENT, SUMMARY, DEMO_SITE_URL, START_DATE, END_DATE,
+                        PLANNING_PROGRESS.toString(), 1L, 2L, 3L, 4L) : saveProjectRequestDto)
         );
         return projectRepository.save(project);
     }

--- a/src/test/java/com/sendback/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/sendback/domain/project/service/ProjectServiceTest.java
@@ -2,9 +2,9 @@ package com.sendback.domain.project.service;
 
 import com.sendback.domain.field.entity.Field;
 import com.sendback.domain.field.service.FieldService;
-import com.sendback.domain.project.dto.request.SaveProjectRequest;
-import com.sendback.domain.project.dto.request.UpdateProjectRequest;
-import com.sendback.domain.project.dto.response.ProjectIdResponse;
+import com.sendback.domain.project.dto.request.SaveProjectRequestDto;
+import com.sendback.domain.project.dto.request.UpdateProjectRequestDto;
+import com.sendback.domain.project.dto.response.ProjectIdResponseDto;
 import com.sendback.domain.project.entity.Project;
 import com.sendback.domain.project.entity.ProjectImage;
 import com.sendback.domain.project.repository.ProjectImageRepository;
@@ -55,8 +55,8 @@ public class ProjectServiceTest extends ServiceTest {
             mockingMultipartFile("sendback2.jpg"), mockingMultipartFile("sendback3.jpg"));
     private final Field eduField = Field.of("edu");
     private final static Long SPYING_PROJECT_ID = 1L;
-    private final SaveProjectRequest saveProjectRequest = mock_saveProjectRequest;
-    private final UpdateProjectRequest updateProjectRequest = mock_updateProjectRequest;
+    private final SaveProjectRequestDto saveProjectRequestDto = MOCK___SAVE_PROJECT_REQUEST_DTO;
+    private final UpdateProjectRequestDto updateProjectRequestDto = MOCK___UPDATE_PROJECT_REQUEST_DTO;
 
     @BeforeEach
     public void setUp() {
@@ -69,12 +69,12 @@ public class ProjectServiceTest extends ServiceTest {
     public void saveProject_success() throws Exception {
         //given
         given(userService.getUserById(any())).willReturn(user);
-        given(fieldService.getFieldByName(saveProjectRequest.field())).willReturn(eduField);
+        given(fieldService.getFieldByName(saveProjectRequestDto.field())).willReturn(eduField);
         given(projectRepository.save(any())).willReturn(project);
         when(project.getId()).thenReturn(SPYING_PROJECT_ID);
 
         //when
-        ProjectIdResponse response = projectService.saveProject(1L, saveProjectRequest, List.of());
+        ProjectIdResponseDto response = projectService.saveProject(1L, saveProjectRequestDto, List.of());
 
         //then
         assertThat(response.projectId()).isEqualTo(1L);
@@ -85,14 +85,14 @@ public class ProjectServiceTest extends ServiceTest {
     public void saveProjectContainImage_success() throws Exception {
         //given
         given(userService.getUserById(any())).willReturn(user);
-        given(fieldService.getFieldByName(saveProjectRequest.field())).willReturn(eduField);
+        given(fieldService.getFieldByName(saveProjectRequestDto.field())).willReturn(eduField);
         given(imageService.upload(images, "project")).willReturn(List.of("sendback1.jpg", "sendback2.jpg", "sendback3.jpg"));
         given(projectRepository.save(any())).willReturn(project);
         when(project.getId()).thenReturn(SPYING_PROJECT_ID);
 
 
         //when
-        ProjectIdResponse response = projectService.saveProject(1L, saveProjectRequest, images);
+        ProjectIdResponseDto response = projectService.saveProject(1L, saveProjectRequestDto, images);
         //then
         assertThat(response.projectId()).isEqualTo(1L);
         verify(projectImageRepository, times(3)).save(any());
@@ -105,16 +105,16 @@ public class ProjectServiceTest extends ServiceTest {
         @DisplayName("프로젝트를 찾을 수 없으면 예외를 발생한다.")
         public void fail_notFoundProject() throws Exception {
             //given
-            UpdateProjectRequest updateProjectRequest = new UpdateProjectRequest(project.getTitle(), project.getField().toString(), project.getContent(), project.getSummary(), project.getDemoSiteUrl(),
+            UpdateProjectRequestDto updateProjectRequestDto = new UpdateProjectRequestDto(project.getTitle(), project.getField().toString(), project.getContent(), project.getSummary(), project.getDemoSiteUrl(),
                     project.getStartedAt(), project.getEndedAt(),
                     project.getProgress().toString(), project.getProjectParticipantCount().getPlannerCount(), project.getProjectParticipantCount().getFrontendCount(),
                     project.getProjectParticipantCount().getBackendCount(), project.getProjectParticipantCount().getDesignCount(), List.of());
             given(userService.getUserById(anyLong())).willReturn(user);
-            given(fieldService.getFieldByName(updateProjectRequest.field())).willReturn(eduField);
+            given(fieldService.getFieldByName(updateProjectRequestDto.field())).willReturn(eduField);
             given(projectRepository.findById(anyLong())).willReturn(Optional.empty());
 
             //when - then
-            assertThatThrownBy(() -> projectService.updateProject(1L, 1L, updateProjectRequest, List.of()))
+            assertThatThrownBy(() -> projectService.updateProject(1L, 1L, updateProjectRequestDto, List.of()))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage(NOT_FOUND_PROJECT.getMessage());
         }
@@ -124,12 +124,12 @@ public class ProjectServiceTest extends ServiceTest {
         public void fail_notAuthor() throws Exception {
             //given
             given(userService.getUserById(anyLong())).willReturn(user);
-            given(fieldService.getFieldByName(updateProjectRequest.field())).willReturn(eduField);
+            given(fieldService.getFieldByName(updateProjectRequestDto.field())).willReturn(eduField);
             given(projectRepository.findById(anyLong())).willReturn(Optional.of(project));
             given(project.isAuthor(user)).willReturn(false);
 
             //when - then
-            assertThatThrownBy(() -> projectService.updateProject(1L, 1L, updateProjectRequest, List.of()))
+            assertThatThrownBy(() -> projectService.updateProject(1L, 1L, updateProjectRequestDto, List.of()))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage(NOT_PROJECT_AUTHOR.getMessage());
         }
@@ -139,13 +139,13 @@ public class ProjectServiceTest extends ServiceTest {
         public void fail_notFoundDeleteUrls() throws Exception {
             //given
             given(userService.getUserById(anyLong())).willReturn(user);
-            given(fieldService.getFieldByName(updateProjectRequest.field())).willReturn(eduField);
+            given(fieldService.getFieldByName(updateProjectRequestDto.field())).willReturn(eduField);
             given(projectRepository.findById(anyLong())).willReturn(Optional.of(project));
             given(project.isAuthor(user)).willReturn(true);
             given(projectImageRepository.findByProjectAndImageUrl(any(Project.class), anyString())).willReturn(Optional.empty());
 
             //when - then
-            assertThatThrownBy(() -> projectService.updateProject(1L, 1L, updateProjectRequest, List.of()))
+            assertThatThrownBy(() -> projectService.updateProject(1L, 1L, updateProjectRequestDto, List.of()))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage(NOT_FOUND_DELETE_IMAGE_URL.getMessage());
         }
@@ -156,7 +156,7 @@ public class ProjectServiceTest extends ServiceTest {
             //given
             ProjectImage projectImage = ProjectImage.of(project, "url");
             given(userService.getUserById(anyLong())).willReturn(user);
-            given(fieldService.getFieldByName(updateProjectRequest.field())).willReturn(eduField);
+            given(fieldService.getFieldByName(updateProjectRequestDto.field())).willReturn(eduField);
             given(projectRepository.findById(anyLong())).willReturn(Optional.of(project));
             given(project.isAuthor(user)).willReturn(true);
             given(projectImageRepository.findByProjectAndImageUrl(any(Project.class), anyString())).willReturn(Optional.of(projectImage));
@@ -164,11 +164,11 @@ public class ProjectServiceTest extends ServiceTest {
             when(project.getId()).thenReturn(SPYING_PROJECT_ID);
 
             //when
-            ProjectIdResponse response = projectService.updateProject(1L, 1L, updateProjectRequest, images);
+            ProjectIdResponseDto response = projectService.updateProject(1L, 1L, updateProjectRequestDto, images);
 
             //then
             assertThat(response.projectId()).isEqualTo(1L);
-            assertThat(project.getTitle()).isEqualTo(updateProjectRequest.title());
+            assertThat(project.getTitle()).isEqualTo(updateProjectRequestDto.title());
         }
     }
 

--- a/src/test/java/com/sendback/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/sendback/domain/project/service/ProjectServiceTest.java
@@ -14,26 +14,18 @@ import com.sendback.domain.user.service.UserService;
 import com.sendback.global.ServiceTest;
 import com.sendback.global.config.image.service.ImageService;
 import com.sendback.global.exception.type.BadRequestException;
-import com.sendback.global.exception.type.ImageException;
 import com.sendback.global.exception.type.NotFoundException;
 import org.junit.jupiter.api.*;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
 import static com.sendback.domain.project.exception.ProjectExceptionType.*;
 import static com.sendback.domain.project.fixture.ProjectFixture.*;
 import static com.sendback.domain.user.fixture.UserFixture.createDummyUser;
-import static com.sendback.global.config.image.exception.ImageExceptionType.AWS_S3_UPLOAD_FAIL;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
@@ -224,26 +216,6 @@ public class ProjectServiceTest extends ServiceTest {
 
             //when - then
             assertDoesNotThrow(() -> projectService.deleteProject(1L, 1L));
-        }
-    }
-
-    private MultipartFile mockingMultipartFile(String fileName) {
-        return new MockMultipartFile(
-                "images",
-                fileName,
-                MediaType.IMAGE_JPEG_VALUE,
-                generateMockImage()
-        );
-    }
-
-    private byte[] generateMockImage() {
-        BufferedImage image = new BufferedImage(100, 100, BufferedImage.TYPE_INT_RGB);
-
-        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
-            ImageIO.write(image, "jpg", byteArrayOutputStream);
-            return byteArrayOutputStream.toByteArray();
-        } catch (IOException e) {
-            throw new ImageException(AWS_S3_UPLOAD_FAIL);
         }
     }
 

--- a/src/test/java/com/sendback/domain/scrap/controller/ScrapControllerTest.java
+++ b/src/test/java/com/sendback/domain/scrap/controller/ScrapControllerTest.java
@@ -1,6 +1,6 @@
 package com.sendback.domain.scrap.controller;
 
-import com.sendback.domain.scrap.dto.response.ClickScrapResponse;
+import com.sendback.domain.scrap.dto.response.ClickScrapResponseDto;
 import com.sendback.global.ControllerTest;
 import com.sendback.global.WithMockCustomUser;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +35,7 @@ public class ScrapControllerTest extends ControllerTest {
     public void success() throws Exception {
         //given
         Long projectId = 1L;
-        ClickScrapResponse response = new ClickScrapResponse(true);
+        ClickScrapResponseDto response = new ClickScrapResponseDto(true);
         given(scrapService.click(anyLong(), anyLong())).willReturn(response);
 
         //when

--- a/src/test/java/com/sendback/domain/scrap/controller/ScrapControllerTest.java
+++ b/src/test/java/com/sendback/domain/scrap/controller/ScrapControllerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -38,10 +39,13 @@ public class ScrapControllerTest extends ControllerTest {
         given(scrapService.click(anyLong(), anyLong())).willReturn(response);
 
         //when
-        mockMvc.perform(put("/api/projects/{projectId}/scrap", projectId)
-                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX+"AccessToken")
+        ResultActions resultActions = mockMvc.perform(put("/api/projects/{projectId}/scrap", projectId)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken")
                         .accept(MediaType.APPLICATION_JSON).with(csrf()))
-                .andDo(print())
+                .andDo(print());
+
+        //then
+        resultActions
                 .andDo(document("scrap/click",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),

--- a/src/test/java/com/sendback/domain/scrap/service/ScrapServiceTest.java
+++ b/src/test/java/com/sendback/domain/scrap/service/ScrapServiceTest.java
@@ -2,7 +2,7 @@ package com.sendback.domain.scrap.service;
 
 import com.sendback.domain.project.entity.Project;
 import com.sendback.domain.project.service.ProjectService;
-import com.sendback.domain.scrap.dto.response.ClickScrapResponse;
+import com.sendback.domain.scrap.dto.response.ClickScrapResponseDto;
 import com.sendback.domain.scrap.entity.Scrap;
 import com.sendback.domain.scrap.repository.ScrapRepository;
 import com.sendback.domain.user.entity.User;
@@ -65,10 +65,10 @@ public class ScrapServiceTest extends ServiceTest {
             given(scrapRepository.save(any(Scrap.class))).willReturn(scrap);
 
             //when
-            ClickScrapResponse clickScrapResponse = scrapService.click(1L, 1L);
+            ClickScrapResponseDto clickScrapResponseDto = scrapService.click(1L, 1L);
 
             //then
-            assertThat(clickScrapResponse.isClicked()).isTrue();
+            assertThat(clickScrapResponseDto.isClicked()).isTrue();
         }
 
         @Test
@@ -80,10 +80,10 @@ public class ScrapServiceTest extends ServiceTest {
             given(scrapRepository.findByUserAndProject(any(User.class), any(Project.class))).willReturn(Optional.of(scrap));
 
             //when
-            ClickScrapResponse clickScrapResponse = scrapService.click(1L, 1L);
+            ClickScrapResponseDto clickScrapResponseDto = scrapService.click(1L, 1L);
 
             //then
-            assertThat(clickScrapResponse.isClicked()).isFalse();
+            assertThat(clickScrapResponseDto.isClicked()).isFalse();
         }
 
         @Test
@@ -97,10 +97,10 @@ public class ScrapServiceTest extends ServiceTest {
             given(scrapRepository.findByUserAndProject(any(User.class), any(Project.class))).willReturn(Optional.of(scrap));
 
             //when
-            ClickScrapResponse clickScrapResponse = scrapService.click(1L, 1L);
+            ClickScrapResponseDto clickScrapResponseDto = scrapService.click(1L, 1L);
 
             //then
-            assertThat(clickScrapResponse.isClicked()).isTrue();
+            assertThat(clickScrapResponseDto.isClicked()).isTrue();
         }
     }
 }

--- a/src/test/java/com/sendback/global/ControllerTest.java
+++ b/src/test/java/com/sendback/global/ControllerTest.java
@@ -5,6 +5,8 @@ import com.sendback.domain.auth.controller.AuthController;
 import com.sendback.domain.auth.service.AuthService;
 import com.sendback.domain.auth.service.GoogleService;
 import com.sendback.domain.auth.service.KakaoService;
+import com.sendback.domain.feedback.controller.FeedbackController;
+import com.sendback.domain.feedback.service.FeedbackService;
 import com.sendback.domain.like.controller.LikeController;
 import com.sendback.domain.like.service.LikeService;
 import com.sendback.domain.project.controller.ProjectController;
@@ -17,6 +19,8 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -25,7 +29,8 @@ import org.springframework.test.web.servlet.MockMvc;
         ProjectController.class,
         LikeController.class,
         ScrapController.class,
-        AuthController.class
+        AuthController.class,
+        FeedbackController.class
 })
 @ActiveProfiles("test")
 @AutoConfigureRestDocs
@@ -55,6 +60,17 @@ public abstract class ControllerTest {
     @MockBean
     protected AuthService authService;
 
+    @MockBean
+    protected FeedbackService feedbackService;
+
     protected static final String ACCESS_TOKEN_PREFIX = "Bearer ";
 
+    protected MockMultipartFile mockingMultipartFile(String fileName) {
+        return new MockMultipartFile(
+                "images",
+                fileName,
+                MediaType.IMAGE_JPEG_VALUE,
+                "mock image".getBytes()
+        );
+    }
 }

--- a/src/test/java/com/sendback/global/RepositoryTest.java
+++ b/src/test/java/com/sendback/global/RepositoryTest.java
@@ -1,5 +1,7 @@
 package com.sendback.global;
 
+import com.sendback.domain.feedback.persister.FeedbackSubmitTestPersister;
+import com.sendback.domain.feedback.persister.FeedbackTestPersister;
 import com.sendback.domain.field.persister.FieldTestPersister;
 import com.sendback.domain.like.persister.LikeTestPersister;
 import com.sendback.domain.project.persister.ProjectImageTestPersister;
@@ -45,4 +47,11 @@ public abstract class RepositoryTest {
 
     @Autowired
     protected ScrapTestPersister scrapTestPersister;
+
+    @Autowired
+    protected FeedbackTestPersister feedbackTestPersister;
+
+    @Autowired
+    protected FeedbackSubmitTestPersister feedbackSubmitTestPersister;
+
 }

--- a/src/test/java/com/sendback/global/ServiceTest.java
+++ b/src/test/java/com/sendback/global/ServiceTest.java
@@ -1,8 +1,40 @@
 package com.sendback.global;
 
+import com.sendback.global.exception.type.ImageException;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static com.sendback.global.config.image.exception.ImageExceptionType.AWS_S3_UPLOAD_FAIL;
 
 @ExtendWith(MockitoExtension.class)
 public abstract class ServiceTest {
+
+    protected MultipartFile mockingMultipartFile(String fileName) {
+        return new MockMultipartFile(
+                "images",
+                fileName,
+                MediaType.IMAGE_JPEG_VALUE,
+                generateMockImage()
+        );
+    }
+
+    private byte[] generateMockImage() {
+        BufferedImage image = new BufferedImage(100, 100, BufferedImage.TYPE_INT_RGB);
+
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
+            ImageIO.write(image, "jpg", byteArrayOutputStream);
+            return byteArrayOutputStream.toByteArray();
+        } catch (IOException e) {
+            throw new ImageException(AWS_S3_UPLOAD_FAIL);
+        }
+    }
+
 }


### PR DESCRIPTION
## 📕 연관 이슈 번호
#21 

## 📙 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 피드백 등록, 상세 조회, 제출 API
- [x] 테스트 코드
- [x] 레벨업 로직
- [x] 유효성 검사
- [x] 피드백 rest docs 추가 및 형식 공통화

## 📗 논의 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 아래 사진처럼 controller 단에서 when then 구분하는게 어때요? 깔끔해보여요!
![image](https://github.com/dnd-side-project/dnd-10th-7-backend/assets/114072164/82f18c8b-86f3-4b4d-a5bb-3b7bd0bcd4a0)

- AuthControllerDocsTest -> AuthControllerTest로 바꾸는거 어때요? ControllerTest 상속받는 거로 바껴서 AuthControllerTest로 다른 컨트롤러랑 공통 시켜요!!

## 📘 체크리스트
- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요.
