### PR TITLE
test : csrf visible 삭제

### DIFF
--- a/src/test/java/com/sendback/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/sendback/domain/auth/controller/AuthControllerTest.java
@@ -57,7 +57,7 @@ public class AuthControllerTest extends ControllerTest {
                     .andExpect(jsonPath("$.data.accessToken").value(accessToken))
                     .andExpect(jsonPath("$.data.refreshToken").value(refreshToken))
                     .andDo(document("login-kakao-success",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             queryParameters(
                                     parameterWithName("code").description("인가 코드")
@@ -96,7 +96,7 @@ public class AuthControllerTest extends ControllerTest {
                     .andExpect(jsonPath("$.message").value("추가 정보를 입력하세요."))
                     .andExpect(jsonPath("$.data.signToken").value("test_sign_token"))
                     .andDo(document("login-kakao-failure",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             queryParameters(
                                     parameterWithName("code").description("인가 코드")
@@ -143,7 +143,7 @@ public class AuthControllerTest extends ControllerTest {
                     .andExpect(jsonPath("$.data.refreshToken").value(refreshToken))
                     .andDo(print())
                     .andDo(document("login-google-success",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             queryParameters(
                                     parameterWithName("code").description("인가 코드")
@@ -185,7 +185,7 @@ public class AuthControllerTest extends ControllerTest {
 
             // then
             resultActions.andDo(document("login-google-failure",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             queryParameters(
                                     parameterWithName("code").description("인가 코드")
@@ -237,7 +237,7 @@ public class AuthControllerTest extends ControllerTest {
 
             // then
             resultActions.andDo(document("reissue-token",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             requestFields(
                                     fieldWithPath("refreshToken").type(JsonFieldType.STRING)
@@ -272,7 +272,7 @@ public class AuthControllerTest extends ControllerTest {
             ResultActions resultActions = mockMvc.perform(post("/api/auth/logout")
                             // 인증정보 설정
                             .contentType(MediaType.APPLICATION_JSON)
-                            .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken").with(csrf()))
+                            .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken").with(csrf().asHeader()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value("200"))
                     .andExpect(jsonPath("$.message").value("성공"))
@@ -281,7 +281,7 @@ public class AuthControllerTest extends ControllerTest {
             // then
             resultActions
                     .andDo(document("logout-social",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             responseFields(
                                     fieldWithPath("code").type(JsonFieldType.NUMBER)

--- a/src/test/java/com/sendback/domain/feedback/controller/FeedbackControllerTest.java
+++ b/src/test/java/com/sendback/domain/feedback/controller/FeedbackControllerTest.java
@@ -54,13 +54,13 @@ public class FeedbackControllerTest extends ControllerTest {
             ResultActions resultActions = mockMvc.perform(post("/api/projects/{projectId}/feedbacks", 1L)
                             .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(saveFeedbackRequestDto)).with(csrf()))
+                            .content(objectMapper.writeValueAsString(saveFeedbackRequestDto)).with(csrf().asHeader()))
                     .andDo(print());
 
             //then
             resultActions
                     .andDo(document("feedback/save",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             pathParameters(
                                     parameterWithName("projectId").description("프로젝트 ID")
@@ -107,13 +107,13 @@ public class FeedbackControllerTest extends ControllerTest {
             given(feedbackService.getFeedbackDetail(anyLong(), anyLong())).willReturn(mockFeedbackDetailResponseDto);
 
             //when
-            ResultActions resultActions = mockMvc.perform(get("/api/projects/{projectId}/feedbacks/{feedbackId}", projectId, feedbackId).with(csrf()))
-                    .andDo(print());
+            ResultActions resultActions = mockMvc.perform(get("/api/projects/{projectId}/feedbacks/{feedbackId}", projectId, feedbackId)
+                            .with(csrf().asHeader())).andDo(print());
 
             //then
             resultActions
                     .andDo(document("feedback/detail",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             pathParameters(
                                     parameterWithName("projectId").description("프로젝트 ID"),
@@ -189,14 +189,13 @@ public class FeedbackControllerTest extends ControllerTest {
             ResultActions resultActions = mockMvc.perform(multipart("/api/projects/{projectId}/feedbacks/{feedbackId}", projectId, feedbackId)
                     .file(mockMultipartFile)
                     .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken")
-                    .contentType(MediaType.MULTIPART_FORM_DATA).with(csrf()));
-            resultActions
-                    .andDo(print());
+                    .contentType(MediaType.MULTIPART_FORM_DATA).with(csrf().asHeader()));
 
             //then
             resultActions
+                    .andDo(print())
                     .andDo(document("feedback/submit",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             pathParameters(
                                     parameterWithName("projectId").description("프로젝트 ID"),

--- a/src/test/java/com/sendback/domain/feedback/service/FeedbackServiceTest.java
+++ b/src/test/java/com/sendback/domain/feedback/service/FeedbackServiceTest.java
@@ -1,9 +1,7 @@
 package com.sendback.domain.feedback.service;
 
 import com.sendback.domain.feedback.dto.request.SaveFeedbackRequestDto;
-import com.sendback.domain.feedback.dto.response.FeedbackDetailResponseDto;
-import com.sendback.domain.feedback.dto.response.FeedbackIdResponseDto;
-import com.sendback.domain.feedback.dto.response.SubmitFeedbackResponseDto;
+import com.sendback.domain.feedback.dto.response.*;
 import com.sendback.domain.feedback.entity.Feedback;
 import com.sendback.domain.feedback.entity.FeedbackSubmit;
 import com.sendback.domain.feedback.repository.FeedbackRepository;
@@ -69,6 +67,47 @@ public class FeedbackServiceTest extends ServiceTest {
         this.project = spy(createDummyProject(user));
         this.feedback = spy(createDummyFeedback(user, project));
     }
+
+//    @Nested
+//    @DisplayName("특정 프로젝트 피드백 리스트 조회 시")
+//    class getFeedbacks {
+//
+//        @Test
+//        @DisplayName("로그인 안한 유저가 정상적인 요청시 값을 반환한다.")
+//        public void success_anonymous() throws Exception {
+//            //given
+//            given(projectService.getProjectById(anyLong())).willReturn(project);
+//            given(feedbackRepository.findTop3ByProjectIsDeletedIsFalseOrderByIdDesc(any(Project.class))).willReturn(List.of(feedback));
+//            given(feedback.getId()).willReturn(1L);
+//
+//            //when
+//            GetFeedbacksResponse response = feedbackService.getFeedbacks(null, 1L);
+//
+//            //then
+//            assertThat(response.feedbacks().size()).isEqualTo(1L);
+//            FeedbackResponse feedbackResponse = response.feedbacks().get(0);
+//            assertThat(feedbackResponse.feedbackId()).isEqualTo(1L);
+//            assertThat(feedbackResponse.title()).isEqualTo(feedback.getTitle());
+//            assertThat(feedbackResponse.rewardMessage()).isEqualTo(feedback.getRewardMessage());
+//            assertThat(feedbackResponse.isAuthor()).isEqualTo(false);
+//            assertThat(feedbackResponse.isSubmitted()).isEqualTo(false);
+//
+//        }
+
+//        @Test
+//        @DisplayName("로그인 한 유저가 정상적인 접근 시 값을 반환한다.")
+//        public void success() throws Exception {
+//            //given
+//            given(projectService.getProjectById(anyLong())).willReturn(project);
+//            given(feedbackRepository.findTop3ByProjectIsDeletedIsFalseOrderByIdDesc(any(Project.class))).willReturn(List.of(feedback));
+//
+//            //when
+//
+//            //then
+//
+//        }
+//
+//    }
 
     @Nested
     @DisplayName("피드백 등록 시")

--- a/src/test/java/com/sendback/domain/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/sendback/domain/like/controller/LikeControllerTest.java
@@ -43,13 +43,13 @@ public class LikeControllerTest extends ControllerTest {
         //when
         ResultActions resultActions = mockMvc.perform(put("/api/projects/{projectId}/like", projectId)
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken")
-                        .accept(MediaType.APPLICATION_JSON).with(csrf()))
+                        .accept(MediaType.APPLICATION_JSON).with(csrf().asHeader()))
                 .andDo(print());
 
         //then
         resultActions
                 .andDo(document("like/react",
-                        preprocessRequest(prettyPrint()),
+                        customRequestPreprocessor(),
                         preprocessResponse(prettyPrint()),
                         pathParameters(
                                 parameterWithName("projectId").description("프로젝트 ID")

--- a/src/test/java/com/sendback/domain/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/sendback/domain/project/controller/ProjectControllerTest.java
@@ -55,13 +55,13 @@ public class ProjectControllerTest extends ControllerTest {
             given(projectService.getProjectDetail(any(), any())).willReturn(projectDetailResponseDto);
 
             //when
-            ResultActions resultActions = mockMvc.perform(get("/api/projects/{projectId}", projectId).with(csrf()))
+            ResultActions resultActions = mockMvc.perform(get("/api/projects/{projectId}", projectId).with(csrf().asHeader()))
                     .andDo(print());
 
             //then
             resultActions
                     .andDo(document("project/detail",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             pathParameters(
                                     parameterWithName("projectId").description("프로젝트 ID")
@@ -151,7 +151,7 @@ public class ProjectControllerTest extends ControllerTest {
                             .file(data)
                             .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken")
                             .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                            .accept(MediaType.APPLICATION_JSON).with(csrf()))
+                            .accept(MediaType.APPLICATION_JSON).with(csrf().asHeader()))
                     .andExpect(jsonPath("$.code").value("200"))
                     .andExpect(jsonPath("$.message").value("성공"))
                     .andExpect(jsonPath("$.data.projectId").value(1))
@@ -160,7 +160,7 @@ public class ProjectControllerTest extends ControllerTest {
             //then
             resultActions
                     .andDo(document("project/save",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             requestHeaders(
                                     headerWithName("Authorization").description("JWT 엑세스 토큰")
@@ -211,7 +211,7 @@ public class ProjectControllerTest extends ControllerTest {
                             .file(data)
                             .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX+"AccessToken")
                             .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                            .accept(MediaType.APPLICATION_JSON).with(csrf()))
+                            .accept(MediaType.APPLICATION_JSON).with(csrf().asHeader()))
                     .andDo(print())
                     .andExpect(jsonPath("$.code").value("200"))
                     .andExpect(jsonPath("$.message").value("성공"))
@@ -228,13 +228,13 @@ public class ProjectControllerTest extends ControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken")
                             .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                            .accept(MediaType.APPLICATION_JSON).with(csrf()))
+                            .accept(MediaType.APPLICATION_JSON).with(csrf().asHeader()))
                     .andDo(print());
 
             //then
             resultActions
                     .andDo(document("project/save/failByNotExistData",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             requestHeaders(
                                     headerWithName("Authorization").description("JWT 엑세스 토큰")
@@ -277,13 +277,13 @@ public class ProjectControllerTest extends ControllerTest {
                             })
                             .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken")
                             .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                            .accept(MediaType.APPLICATION_JSON).with(csrf()))
+                            .accept(MediaType.APPLICATION_JSON).with(csrf().asHeader()))
                     .andDo(print());
 
             //then
             resultActions
                     .andDo(document("project/update",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             pathParameters(
                                     parameterWithName("projectId").description("프로젝트 ID")
@@ -341,13 +341,13 @@ public class ProjectControllerTest extends ControllerTest {
                             })
                             .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken")
                             .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                            .accept(MediaType.APPLICATION_JSON).with(csrf()))
+                            .accept(MediaType.APPLICATION_JSON).with(csrf().asHeader()))
                     .andDo(print());
 
             //then
             resultActions
                     .andDo(document("project/update/failByNotExistData",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             pathParameters(
                                     parameterWithName("projectId").description("프로젝트 ID")
@@ -384,13 +384,13 @@ public class ProjectControllerTest extends ControllerTest {
             //when
             ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.delete("/api/projects/{projectId}", projectId)
                             .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken")
-                            .accept(MediaType.APPLICATION_JSON).with(csrf()))
+                            .accept(MediaType.APPLICATION_JSON).with(csrf().asHeader()))
                     .andDo(print());
 
             //then
             resultActions
                     .andDo(document("project/delete",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             pathParameters(
                                     parameterWithName("projectId").description("프로젝트 ID")

--- a/src/test/java/com/sendback/domain/scrap/controller/ScrapControllerTest.java
+++ b/src/test/java/com/sendback/domain/scrap/controller/ScrapControllerTest.java
@@ -41,13 +41,13 @@ public class ScrapControllerTest extends ControllerTest {
         //when
         ResultActions resultActions = mockMvc.perform(put("/api/projects/{projectId}/scrap", projectId)
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken")
-                        .accept(MediaType.APPLICATION_JSON).with(csrf()))
+                        .accept(MediaType.APPLICATION_JSON).with(csrf().asHeader()))
                 .andDo(print());
 
         //then
         resultActions
                 .andDo(document("scrap/click",
-                        preprocessRequest(prettyPrint()),
+                        customRequestPreprocessor(),
                         preprocessResponse(prettyPrint()),
                         pathParameters(
                                 parameterWithName("projectId").description("프로젝트 ID")

--- a/src/test/java/com/sendback/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/sendback/domain/user/controller/UserControllerTest.java
@@ -55,7 +55,7 @@ public class UserControllerTest extends ControllerTest {
             ResultActions resultActions = mockMvc.perform(
                             post("/api/users/signup")
                                     .contentType(MediaType.APPLICATION_JSON)
-                                    .content(content).with(csrf()))
+                                    .content(content).with(csrf().asHeader()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value("200"))
                     .andExpect(jsonPath("$.message").value("성공"))
@@ -65,7 +65,7 @@ public class UserControllerTest extends ControllerTest {
 
             // then
             resultActions.andDo(document("signUpKakao-success",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             requestFields(
                                     fieldWithPath("nickname").type(JsonFieldType.STRING)
@@ -122,7 +122,7 @@ public class UserControllerTest extends ControllerTest {
             // then
             resultActions
                     .andDo(document("checkUserNickname-success",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             queryParameters(
                                     parameterWithName("nickname").description("닉네임")
@@ -156,7 +156,7 @@ public class UserControllerTest extends ControllerTest {
 
             // when
             ResultActions resultActions = mockMvc.perform(get("/api/users/me")
-                            .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken").with(csrf()))
+                            .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken").with(csrf().asHeader()))
                     // HTTP 상태코드 200 (OK) 확인
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value("200"))
@@ -178,7 +178,7 @@ public class UserControllerTest extends ControllerTest {
             // then
             resultActions
                     .andDo(document("getUserInfo-success",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             responseFields(
                                     fieldWithPath("code").type(JsonFieldType.NUMBER)
@@ -232,7 +232,7 @@ public class UserControllerTest extends ControllerTest {
             // when
             ResultActions resultActions = mockMvc.perform(put("/api/users/me")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(content).with(csrf())
+                            .content(content).with(csrf().asHeader())
                             .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "AccessToken"))
                     // HTTP 상태코드 200 (OK) 확인
                     .andExpect(status().isOk())
@@ -248,7 +248,7 @@ public class UserControllerTest extends ControllerTest {
             // then
             resultActions
                     .andDo(document("updateUserInfo-success",
-                            preprocessRequest(prettyPrint()),
+                            customRequestPreprocessor(),
                             preprocessResponse(prettyPrint()),
                             responseFields(
                                     fieldWithPath("code").type(JsonFieldType.NUMBER)

--- a/src/test/java/com/sendback/global/ControllerTest.java
+++ b/src/test/java/com/sendback/global/ControllerTest.java
@@ -23,8 +23,11 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 
 
 @WebMvcTest({
@@ -78,5 +81,13 @@ public abstract class ControllerTest {
                 MediaType.IMAGE_JPEG_VALUE,
                 "mock image".getBytes()
         );
+    }
+
+    protected OperationRequestPreprocessor customRequestPreprocessor() {
+        return preprocessRequest(
+                modifyHeaders()
+                        .remove("X-CSRF-TOKEN") //csrf 헤더 삭제하기
+                        .remove("Host"),
+                prettyPrint());
     }
 }


### PR DESCRIPTION
## 📕 연관 이슈 번호


## 📙 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] csrf 전체 컨트롤러에 존재하던 것을 헤더로 받아 restdocs에 보여줄 때는 삭제
- [x] 공통 preprocessRequest 생성

## 📗 논의 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 앞으로 csrf().asHeader()로 받고 preprocessRequest() 대신 customRequestPreprocessor() 쓰면 될 것 같습니다!

## 📘 체크리스트
- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요.
